### PR TITLE
Pay For Writes with BCH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ data/
 
 #Backup
 backup/
+
+wallet.json

--- a/.on-save.json
+++ b/.on-save.json
@@ -1,0 +1,8 @@
+[
+  {
+    "srcDir": "",
+    "destDir": "",
+    "files": "**/*.js",
+    "command": "npm run lint"
+  }
+]

--- a/config/env/common.js
+++ b/config/env/common.js
@@ -117,5 +117,8 @@ module.exports = {
     ? parseInt(process.env.IPFS_API_PORT)
     : 5001,
 
-  chatPubSubChan: 'psf-ipfs-chat-001'
+  chatPubSubChan: 'psf-ipfs-chat-001',
+
+  // Markup for providing PSF tokens so user can pay in BCH.
+  psfTradeMarkup: 0.1
 }

--- a/config/env/common.js
+++ b/config/env/common.js
@@ -120,5 +120,8 @@ module.exports = {
   chatPubSubChan: 'psf-ipfs-chat-001',
 
   // Markup for providing PSF tokens so user can pay in BCH.
-  psfTradeMarkup: 0.1
+  psfTradeMarkup: 0.1,
+
+  // Turn on pay-in-bch plugin. Disabled by default. Use env var to overwrite.
+  enableBchPayment: process.env.ENABLE_BCH_PAYMENT ? process.env.ENABLE_BCH_PAYMENT : false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "koa-static": "5.0.0",
         "koa2-ratelimit": "0.9.1",
         "line-reader": "0.4.0",
-        "minimal-slp-wallet": "4.6.5",
+        "minimal-slp-wallet": "5.0.0",
         "mongoose": "5.13.14",
         "node-fetch": "npm:@achingbrain/node-fetch@2.6.7",
         "nodemailer": "6.7.5",
@@ -3376,54 +3376,19 @@
       }
     },
     "node_modules/bch-consumer": {
-      "version": "1.3.0",
-      "license": "MIT",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bch-consumer/-/bch-consumer-1.3.1.tgz",
+      "integrity": "sha512-8ZoyFp4pLJFAOzM482K22sVL2FpuxhkYRtZuLLsMH9L442mRABjsAP7fTh91W5er40r8RGN/CSKi2TMyUmrY1Q==",
       "dependencies": {
-        "@psf/bch-js": "6.3.4",
+        "@psf/bch-js": "6.4.5",
         "apidoc": "0.51.0",
         "axios": "0.25.0"
       }
     },
-    "node_modules/bch-consumer/node_modules/@psf/bch-js": {
-      "version": "6.3.4",
-      "license": "MIT",
-      "dependencies": {
-        "@chris.troutner/bip32-utils": "1.0.5",
-        "@psf/bip21": "2.0.1",
-        "@psf/bitcoincash-ops": "2.0.0",
-        "@psf/bitcoincashjs-lib": "4.0.2",
-        "@psf/coininfo": "4.0.0",
-        "axios": "0.26.1",
-        "bc-bip68": "1.0.5",
-        "bchaddrjs-slp": "0.2.5",
-        "bigi": "1.4.2",
-        "bignumber.js": "9.0.0",
-        "bip-schnorr": "0.3.0",
-        "bip38": "2.0.2",
-        "bip39": "3.0.2",
-        "bip66": "1.1.5",
-        "bitcoinjs-message": "2.0.0",
-        "bs58": "4.0.1",
-        "ecashaddrjs": "1.0.7",
-        "ini": "1.3.8",
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.2",
-        "satoshi-bitcoin": "1.0.4",
-        "slp-mdm": "0.0.6",
-        "slp-parser": "0.0.4",
-        "wif": "2.0.6"
-      }
-    },
-    "node_modules/bch-consumer/node_modules/@psf/bch-js/node_modules/axios": {
-      "version": "0.26.1",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
-      }
-    },
     "node_modules/bch-consumer/node_modules/apidoc": {
       "version": "0.51.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.51.0.tgz",
+      "integrity": "sha512-3P4srhm6NA+kE/YRM4qL5jESElpQQJL+Z8n7hyr4uC+1DSwGzmE6adXPVxuT/hpDyShrqmRlHk8hf40RSqEsNw==",
       "os": [
         "darwin",
         "freebsd",
@@ -3464,21 +3429,24 @@
     },
     "node_modules/bch-consumer/node_modules/axios": {
       "version": "0.25.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "dependencies": {
         "follow-redirects": "^1.14.7"
       }
     },
     "node_modules/bch-consumer/node_modules/commander": {
       "version": "8.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/bch-consumer/node_modules/glob": {
       "version": "7.2.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -11653,45 +11621,15 @@
       }
     },
     "node_modules/minimal-slp-wallet": {
-      "version": "4.6.5",
-      "license": "MIT",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minimal-slp-wallet/-/minimal-slp-wallet-5.0.0.tgz",
+      "integrity": "sha512-Zfb6kTuFBoW9QQWfmUmKQC37kP9L/HRoiQojI60tTTvo4tn0fo57+ua5ia6Ue9I42Z3TQa08xXx80NL8I8ygEw==",
       "dependencies": {
-        "@psf/bch-js": "6.4.1",
+        "@psf/bch-js": "6.4.5",
         "apidoc": "0.51.0",
-        "bch-consumer": "1.3.0",
+        "bch-consumer": "1.3.1",
         "bch-donation": "1.1.2",
         "crypto-js": "4.0.0"
-      }
-    },
-    "node_modules/minimal-slp-wallet/node_modules/@psf/bch-js": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@psf/bch-js/-/bch-js-6.4.1.tgz",
-      "integrity": "sha512-/BLGzWH02VqaDNeY05QGMhrCtYDw5bXn45Egz+L5FLcyZaOqONR4kl80T6a8xvTPcREO4R+AjGTRBpfjdikwpA==",
-      "dependencies": {
-        "@chris.troutner/bip32-utils": "1.0.5",
-        "@psf/bip21": "2.0.1",
-        "@psf/bitcoincash-ops": "2.0.0",
-        "@psf/bitcoincashjs-lib": "4.0.2",
-        "@psf/coininfo": "4.0.0",
-        "axios": "0.26.1",
-        "bc-bip68": "1.0.5",
-        "bchaddrjs-slp": "0.2.5",
-        "bigi": "1.4.2",
-        "bignumber.js": "9.0.0",
-        "bip-schnorr": "0.3.0",
-        "bip38": "2.0.2",
-        "bip39": "3.0.2",
-        "bip66": "1.1.5",
-        "bitcoinjs-message": "2.0.0",
-        "bs58": "4.0.1",
-        "ecashaddrjs": "1.0.7",
-        "ini": "1.3.8",
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.2",
-        "satoshi-bitcoin": "1.0.4",
-        "slp-mdm": "0.0.6",
-        "slp-parser": "0.0.4",
-        "wif": "2.0.6"
       }
     },
     "node_modules/minimal-slp-wallet/node_modules/apidoc": {
@@ -11733,14 +11671,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/minimal-slp-wallet/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/minimal-slp-wallet/node_modules/commander": {
@@ -24080,52 +24010,19 @@
       "version": "1.0.5"
     },
     "bch-consumer": {
-      "version": "1.3.0",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bch-consumer/-/bch-consumer-1.3.1.tgz",
+      "integrity": "sha512-8ZoyFp4pLJFAOzM482K22sVL2FpuxhkYRtZuLLsMH9L442mRABjsAP7fTh91W5er40r8RGN/CSKi2TMyUmrY1Q==",
       "requires": {
-        "@psf/bch-js": "6.3.4",
+        "@psf/bch-js": "6.4.5",
         "apidoc": "0.51.0",
         "axios": "0.25.0"
       },
       "dependencies": {
-        "@psf/bch-js": {
-          "version": "6.3.4",
-          "requires": {
-            "@chris.troutner/bip32-utils": "1.0.5",
-            "@psf/bip21": "2.0.1",
-            "@psf/bitcoincash-ops": "2.0.0",
-            "@psf/bitcoincashjs-lib": "4.0.2",
-            "@psf/coininfo": "4.0.0",
-            "axios": "0.26.1",
-            "bc-bip68": "1.0.5",
-            "bchaddrjs-slp": "0.2.5",
-            "bigi": "1.4.2",
-            "bignumber.js": "9.0.0",
-            "bip-schnorr": "0.3.0",
-            "bip38": "2.0.2",
-            "bip39": "3.0.2",
-            "bip66": "1.1.5",
-            "bitcoinjs-message": "2.0.0",
-            "bs58": "4.0.1",
-            "ecashaddrjs": "1.0.7",
-            "ini": "1.3.8",
-            "randombytes": "2.0.6",
-            "safe-buffer": "5.1.2",
-            "satoshi-bitcoin": "1.0.4",
-            "slp-mdm": "0.0.6",
-            "slp-parser": "0.0.4",
-            "wif": "2.0.6"
-          },
-          "dependencies": {
-            "axios": {
-              "version": "0.26.1",
-              "requires": {
-                "follow-redirects": "^1.14.8"
-              }
-            }
-          }
-        },
         "apidoc": {
           "version": "0.51.0",
+          "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.51.0.tgz",
+          "integrity": "sha512-3P4srhm6NA+kE/YRM4qL5jESElpQQJL+Z8n7hyr4uC+1DSwGzmE6adXPVxuT/hpDyShrqmRlHk8hf40RSqEsNw==",
           "requires": {
             "bootstrap": "3.4.1",
             "commander": "^8.3.0",
@@ -24153,15 +24050,21 @@
         },
         "axios": {
           "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+          "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
           "requires": {
             "follow-redirects": "^1.14.7"
           }
         },
         "commander": {
-          "version": "8.3.0"
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
         },
         "glob": {
           "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -29804,46 +29707,17 @@
       "dev": true
     },
     "minimal-slp-wallet": {
-      "version": "4.6.5",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minimal-slp-wallet/-/minimal-slp-wallet-5.0.0.tgz",
+      "integrity": "sha512-Zfb6kTuFBoW9QQWfmUmKQC37kP9L/HRoiQojI60tTTvo4tn0fo57+ua5ia6Ue9I42Z3TQa08xXx80NL8I8ygEw==",
       "requires": {
-        "@psf/bch-js": "6.4.1",
+        "@psf/bch-js": "6.4.5",
         "apidoc": "0.51.0",
-        "bch-consumer": "1.3.0",
+        "bch-consumer": "1.3.1",
         "bch-donation": "1.1.2",
         "crypto-js": "4.0.0"
       },
       "dependencies": {
-        "@psf/bch-js": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/@psf/bch-js/-/bch-js-6.4.1.tgz",
-          "integrity": "sha512-/BLGzWH02VqaDNeY05QGMhrCtYDw5bXn45Egz+L5FLcyZaOqONR4kl80T6a8xvTPcREO4R+AjGTRBpfjdikwpA==",
-          "requires": {
-            "@chris.troutner/bip32-utils": "1.0.5",
-            "@psf/bip21": "2.0.1",
-            "@psf/bitcoincash-ops": "2.0.0",
-            "@psf/bitcoincashjs-lib": "4.0.2",
-            "@psf/coininfo": "4.0.0",
-            "axios": "0.26.1",
-            "bc-bip68": "1.0.5",
-            "bchaddrjs-slp": "0.2.5",
-            "bigi": "1.4.2",
-            "bignumber.js": "9.0.0",
-            "bip-schnorr": "0.3.0",
-            "bip38": "2.0.2",
-            "bip39": "3.0.2",
-            "bip66": "1.1.5",
-            "bitcoinjs-message": "2.0.0",
-            "bs58": "4.0.1",
-            "ecashaddrjs": "1.0.7",
-            "ini": "1.3.8",
-            "randombytes": "2.0.6",
-            "safe-buffer": "5.1.2",
-            "satoshi-bitcoin": "1.0.4",
-            "slp-mdm": "0.0.6",
-            "slp-parser": "0.0.4",
-            "wif": "2.0.6"
-          }
-        },
         "apidoc": {
           "version": "0.51.0",
           "requires": {
@@ -29869,14 +29743,6 @@
             "webpack": "^5.64.2",
             "webpack-cli": "^4.9.1",
             "winston": "^3.3.3"
-          }
-        },
-        "axios": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-          "requires": {
-            "follow-redirects": "^1.14.8"
           }
         },
         "commander": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "node-fetch": "npm:@achingbrain/node-fetch@2.6.7",
         "nodemailer": "6.7.5",
         "orbit-db": "0.28.0",
+        "p2wdb": "1.4.0",
         "passport-local": "1.0.0",
         "public-ip": "4.0.4",
         "winston": "3.3.3",
@@ -2469,10 +2470,76 @@
       "version": "0.12.0",
       "license": "MIT"
     },
+    "node_modules/@types/tus-js-client": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@types/tus-js-client/-/tus-js-client-1.8.0.tgz",
+      "integrity": "sha512-lWxu5+6qfyfwsW99GzUeJ9y9JeOSSLduKxgYMvaYM7sGTDKZsrIIHTUbHI2P016xhXtu9NxmUM3GrB4i14ie4A=="
+    },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@uppy/companion-client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@uppy/companion-client/-/companion-client-1.10.2.tgz",
+      "integrity": "sha512-5RmsNF9UBvUqmqQz48SoiLvkpGmvQTgwNM4bJX8xwVozv/6goRpFrsMJGLwqFcHS/9xj6STKOqrM582g8exVwQ==",
+      "dependencies": {
+        "@uppy/utils": "^3.6.2",
+        "namespace-emitter": "^2.0.1",
+        "qs-stringify": "^1.1.0",
+        "url-parse": "^1.4.7"
+      }
+    },
+    "node_modules/@uppy/companion-client/node_modules/@uppy/utils": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@uppy/utils/-/utils-3.6.2.tgz",
+      "integrity": "sha512-wGTZma7eywIojfuE1vXlT0fxPSpmCRMkfgFWYc+6TL2FfGqWInmePoB+yal6/M2AnjeKHz6XYMhIpZkjOxFvcw==",
+      "dependencies": {
+        "abortcontroller-polyfill": "^1.4.0",
+        "lodash.throttle": "^4.1.1"
+      }
+    },
+    "node_modules/@uppy/core": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@uppy/core/-/core-1.10.4.tgz",
+      "integrity": "sha512-mORSXL4JyXHGo98u6u0sMzv3wtdI5jjHsqyThQAXx3LvctWE0EBrxE7vJqrXue2z/m9lovsZVhuzP2L7Qkuebg==",
+      "dependencies": {
+        "@uppy/store-default": "^1.2.1",
+        "@uppy/utils": "^2.4.4",
+        "cuid": "^2.1.1",
+        "lodash.throttle": "^4.1.1",
+        "mime-match": "^1.0.2",
+        "namespace-emitter": "^2.0.1",
+        "preact": "8.2.9"
+      }
+    },
+    "node_modules/@uppy/store-default": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@uppy/store-default/-/store-default-1.2.7.tgz",
+      "integrity": "sha512-58IG9yk/i/kYQ9uEwAwMFl1H2V3syOoODrYoFfVHlxaqv+9MkXBg2tHE2gk40iaAIxcCErcPxZkBOvkqzO1SQA=="
+    },
+    "node_modules/@uppy/tus": {
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@uppy/tus/-/tus-1.5.12.tgz",
+      "integrity": "sha512-jDiwsTRHnMfb83ZB8JdDD0uA9DX0K/FqenGMYBGTOlkCjAcXD3sI59DzEHwq2TtY3ZH7iaL3fTNQ7ExBWkwrqw==",
+      "dependencies": {
+        "@types/tus-js-client": "^1.8.0",
+        "@uppy/companion-client": "^1.4.4",
+        "@uppy/utils": "^2.4.4",
+        "tus-js-client": "^1.8.0"
+      },
+      "peerDependencies": {
+        "@uppy/core": "^1.0.0"
+      }
+    },
+    "node_modules/@uppy/utils": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@uppy/utils/-/utils-2.4.4.tgz",
+      "integrity": "sha512-7A0uwK5Rf8XcKqlpNUZ5L5LmkHT5c0/UWjDJGwmzeCxp2lECgzsMC+4vgA6kT4sFzPFbLtUtxHi7ecFwow3NQQ==",
+      "dependencies": {
+        "lodash.throttle": "^4.1.1"
+      }
     },
     "node_modules/@vascosantos/moving-average": {
       "version": "1.1.0",
@@ -2657,6 +2724,11 @@
       "dependencies": {
         "get-iterator": "^1.0.2"
       }
+    },
+    "node_modules/abortcontroller-polyfill": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
+      "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q=="
     },
     "node_modules/abstract-leveldown": {
       "version": "7.2.0",
@@ -2881,6 +2953,36 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/apidoc-core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/apidoc-core/-/apidoc-core-0.12.0.tgz",
+      "integrity": "sha512-VMhkJWz5IAyvWM0RnEbKNi1qe8se+id3/Ki3H/ePM8ih0KYTfaaSDxqo2w4uIVB1UVVKFvrTWyYUyQs7CEcoKQ==",
+      "dependencies": {
+        "fs-extra": "^9.0.1",
+        "glob": "^7.1.6",
+        "iconv-lite": "^0.6.2",
+        "klaw-sync": "^6.0.0",
+        "lodash": "^4.17.20",
+        "semver": "~7.3.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/apidoc-core/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/apidoc/node_modules/commander": {
       "version": "8.3.0",
       "dev": true,
@@ -2941,7 +3043,6 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -3181,6 +3282,14 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -4374,6 +4483,24 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/combine-errors": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/combine-errors/-/combine-errors-3.0.3.tgz",
+      "integrity": "sha512-C8ikRNRMygCwaTx+Ek3Yr+OuZzgZjduCOfSQBjbM8V3MfgcjSTeto/GXP6PAwKvJz/v15b7GHZvx5rOlczFw/Q==",
+      "dependencies": {
+        "custom-error-instance": "2.1.1",
+        "lodash.uniqby": "4.5.0"
+      }
+    },
+    "node_modules/combine-errors/node_modules/lodash.uniqby": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.5.0.tgz",
+      "integrity": "sha512-IRt7cfTtHy6f1aRVA5n7kT8rgN3N1nH6MOWLcHfpWG2SH19E3JksLK38MktLxZDhlAjCP9jpIXkOnRXlu6oByQ==",
+      "dependencies": {
+        "lodash._baseiteratee": "~4.7.0",
+        "lodash._baseuniq": "~4.6.0"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "license": "MIT",
@@ -4736,6 +4863,16 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/cuid": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg=="
+    },
+    "node_modules/custom-error-instance": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/custom-error-instance/-/custom-error-instance-2.1.1.tgz",
+      "integrity": "sha512-p6JFxJc3M4OTD2li2qaHkDCw9SfMw82Ldr6OC9Je1aXiGfhx2W8p3GaoeaGrPJTUN9NirTM/KTxHWMUdR1rsUg=="
     },
     "node_modules/d64": {
       "version": "1.0.0",
@@ -9722,6 +9859,11 @@
       "version": "3.6.0",
       "license": "MIT"
     },
+    "node_modules/js-base64": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+    },
     "node_modules/js-sha256": {
       "version": "0.9.0",
       "license": "MIT"
@@ -11043,6 +11185,46 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash._baseiteratee": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz",
+      "integrity": "sha512-nqB9M+wITz0BX/Q2xg6fQ8mLkyfF7MU7eE+MNBNjTHFKeKaZAPEzEg+E8LWxKWf1DQVflNEn9N49yAuqKh2mWQ==",
+      "dependencies": {
+        "lodash._stringtopath": "~4.8.0"
+      }
+    },
+    "node_modules/lodash._basetostring": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
+      "integrity": "sha512-SwcRIbyxnN6CFEEK4K1y+zuApvWdpQdBHM/swxP962s8HIxPO3alBH5t3m/dl+f4CMUug6sJb7Pww8d13/9WSw=="
+    },
+    "node_modules/lodash._baseuniq": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+      "integrity": "sha512-Ja1YevpHZctlI5beLA7oc5KNDhGcPixFhcqSiORHNsp/1QTv7amAXzw+gu4YOvErqVlMVyIJGgtzeepCnnur0A==",
+      "dependencies": {
+        "lodash._createset": "~4.0.0",
+        "lodash._root": "~3.0.0"
+      }
+    },
+    "node_modules/lodash._createset": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+      "integrity": "sha512-GTkC6YMprrJZCYU3zcqZj+jkXkrXzq3IPBcF/fIPpNEAB4hZEtXU8zp/RwKOvZl43NUmwDbyRk3+ZTbeRdEBXA=="
+    },
+    "node_modules/lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha512-O0pWuFSK6x4EXhM1dhZ8gchNtG7JMqBtrHdoUFUWXD7dJnNSUze1GuyQr5sOs0aCvgGeI3o/OJW8f4ca7FDxmQ=="
+    },
+    "node_modules/lodash._stringtopath": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/lodash._stringtopath/-/lodash._stringtopath-4.8.0.tgz",
+      "integrity": "sha512-SXL66C731p0xPDC5LZg4wI5H+dJo/EO4KTqOMwLYCH3+FmmfAKJEZCm6ohGpI+T1xwsDsJCfL4OnhorllvlTPQ==",
+      "dependencies": {
+        "lodash._basetostring": "~4.12.0"
+      }
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "license": "MIT"
@@ -11428,6 +11610,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mime-match/-/mime-match-1.0.2.tgz",
+      "integrity": "sha512-VXp/ugGDVh3eCLOBCiHZMYWQaTNUHv2IJrut+yXA6+JbLPXHglHwfS/5A5L0ll+jkCY7fIzRJcH6OIunF+c6Cg==",
+      "dependencies": {
+        "wildcard": "^1.1.0"
       }
     },
     "node_modules/mime-types": {
@@ -12233,6 +12423,11 @@
         "node": ">=6.X.X",
         "npm": ">=3.X.X"
       }
+    },
+    "node_modules/namespace-emitter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/namespace-emitter/-/namespace-emitter-2.0.1.tgz",
+      "integrity": "sha512-N/sMKHniSDJBjfrkbS/tpkPj4RAbvW3mr8UAzvlMHyun93XEm83IAvhWtJVHo+RHn/oO8Job5YN4b+wRjSVp5g=="
     },
     "node_modules/nan": {
       "version": "2.15.0",
@@ -16483,6 +16678,199 @@
         "node": ">=8"
       }
     },
+    "node_modules/p2wdb": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/p2wdb/-/p2wdb-1.4.0.tgz",
+      "integrity": "sha512-YbwxKdaT8yKvE+vEGJYfOdquASOgYY0C4OP7h4jd8ceHg5w+dxUnPrjAF2ll7fXx02y2vPndAKgSBStvBYZL/A==",
+      "dependencies": {
+        "apidoc": "0.25.0",
+        "axios": "0.24.0",
+        "minimal-slp-wallet": "4.4.2"
+      }
+    },
+    "node_modules/p2wdb/node_modules/@psf/bch-js": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@psf/bch-js/-/bch-js-5.3.2.tgz",
+      "integrity": "sha512-LzYekwuee+T8AEZ1MKBe5KnZKXzpRZ57SpXRL2S8qsHefokTIN+XnDPX7dsOFkN4VGGgyjYyZ33iN6xhOSHWJw==",
+      "dependencies": {
+        "@chris.troutner/bip32-utils": "1.0.5",
+        "@psf/bip21": "2.0.1",
+        "@psf/bitcoincash-ops": "2.0.0",
+        "@psf/bitcoincashjs-lib": "4.0.2",
+        "@psf/coininfo": "4.0.0",
+        "@uppy/core": "1.10.4",
+        "@uppy/tus": "1.5.12",
+        "axios": "^0.21.4",
+        "bc-bip68": "1.0.5",
+        "bchaddrjs-slp": "0.2.5",
+        "bigi": "1.4.2",
+        "bignumber.js": "9.0.0",
+        "bip-schnorr": "0.3.0",
+        "bip38": "2.0.2",
+        "bip39": "3.0.2",
+        "bip66": "1.1.5",
+        "bitcoinjs-message": "2.0.0",
+        "bs58": "4.0.1",
+        "ecashaddrjs": "1.0.7",
+        "ini": "1.3.8",
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2",
+        "satoshi-bitcoin": "1.0.4",
+        "slp-mdm": "0.0.6",
+        "slp-parser": "0.0.4",
+        "wif": "2.0.6"
+      }
+    },
+    "node_modules/p2wdb/node_modules/@psf/bch-js/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/p2wdb/node_modules/apidoc": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.25.0.tgz",
+      "integrity": "sha512-5g9fp8OffXZOdBTzm4BBvV5Vw54s+NmKnGZIUKuH+gRTqqJuRJpcGN6sz6WnjJ+NcvXhB7rIRp6FhtJahazx2Q==",
+      "dependencies": {
+        "apidoc-core": "^0.12.0",
+        "commander": "^2.20.0",
+        "fs-extra": "^9.0.1",
+        "handlebars": "^4.7.6",
+        "lodash": "^4.17.20",
+        "markdown-it": "^11.0.0",
+        "nodemon": "^2.0.4",
+        "winston": "^3.3.3"
+      },
+      "bin": {
+        "apidoc": "bin/apidoc"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/p2wdb/node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/p2wdb/node_modules/bch-consumer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bch-consumer/-/bch-consumer-1.2.0.tgz",
+      "integrity": "sha512-RzoJXA95OkXaV4MFAB1wFjdEsn9lmBO7F5lptUMswmpMhyRKhgfKN9m3+gN1Qj9Kiq66YTU2b2EcUlf1Iw1ETA==",
+      "dependencies": {
+        "@psf/bch-js": "5.3.1",
+        "apidoc": "0.25.0",
+        "axios": "0.25.0"
+      }
+    },
+    "node_modules/p2wdb/node_modules/bch-consumer/node_modules/@psf/bch-js": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@psf/bch-js/-/bch-js-5.3.1.tgz",
+      "integrity": "sha512-HoeRM7q+zsTLIqifweEntFDHG35cL0Ps7nnh59CDbBsswpgWcvhPxBmgsHcf9m9SdHsTzHaNgX2WQuYw8nl0bg==",
+      "dependencies": {
+        "@chris.troutner/bip32-utils": "1.0.5",
+        "@psf/bip21": "2.0.1",
+        "@psf/bitcoincash-ops": "2.0.0",
+        "@psf/bitcoincashjs-lib": "4.0.2",
+        "@psf/coininfo": "4.0.0",
+        "@uppy/core": "1.10.4",
+        "@uppy/tus": "1.5.12",
+        "axios": "^0.21.4",
+        "bc-bip68": "1.0.5",
+        "bchaddrjs-slp": "0.2.5",
+        "bigi": "1.4.2",
+        "bignumber.js": "9.0.0",
+        "bip-schnorr": "0.3.0",
+        "bip38": "2.0.2",
+        "bip39": "3.0.2",
+        "bip66": "1.1.5",
+        "bitcoinjs-message": "2.0.0",
+        "bs58": "4.0.1",
+        "ecashaddrjs": "1.0.7",
+        "ini": "1.3.8",
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2",
+        "satoshi-bitcoin": "1.0.4",
+        "slp-mdm": "0.0.6",
+        "slp-parser": "0.0.4",
+        "wif": "2.0.6"
+      }
+    },
+    "node_modules/p2wdb/node_modules/bch-consumer/node_modules/@psf/bch-js/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/p2wdb/node_modules/bch-consumer/node_modules/axios": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "dependencies": {
+        "follow-redirects": "^1.14.7"
+      }
+    },
+    "node_modules/p2wdb/node_modules/bch-donation": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bch-donation/-/bch-donation-1.1.1.tgz",
+      "integrity": "sha512-FDfBlzKoswbpGQHfRez4eddgOdWfWiZPGLZsCNxwxn98LDnykPGJdmDmtg2Gn8ogCvLLTilEolY0YFKwlx+yEg==",
+      "dependencies": {
+        "apidoc": "^0.25.0"
+      }
+    },
+    "node_modules/p2wdb/node_modules/entities": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
+    },
+    "node_modules/p2wdb/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/p2wdb/node_modules/markdown-it": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-11.0.1.tgz",
+      "integrity": "sha512-aU1TzmBKcWNNYvH9pjq6u92BML+Hz3h5S/QpfTFwiQF852pLT+9qHsrhM9JYipkOXZxGn+sGH8oyJE9FD9WezQ==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/p2wdb/node_modules/minimal-slp-wallet": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/minimal-slp-wallet/-/minimal-slp-wallet-4.4.2.tgz",
+      "integrity": "sha512-6JNRnH8mQQb/gmfwdd0KgJeHFJycK60EDmeEdjghvm1I2J0z2HVI3gZzrVqjBC/tBDYKtuDuvRtix7q2LqKqhw==",
+      "dependencies": {
+        "@psf/bch-js": "5.3.2",
+        "apidoc": "0.25.0",
+        "bch-consumer": "1.2.0",
+        "bch-donation": "1.1.1",
+        "crypto-js": "4.0.0"
+      }
+    },
     "node_modules/package-hash": {
       "version": "4.0.0",
       "dev": true,
@@ -17121,6 +17509,12 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "node_modules/preact": {
+      "version": "8.2.9",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.9.tgz",
+      "integrity": "sha512-ThuGXBmJS3VsT+jIP+eQufD3L8pRw/PY3FoCys6O9Pu6aF12Pn9zAJDX99TfwRAFOCEKm/P0lwiPTbqKMJp0fA==",
+      "hasInstallScript": true
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
@@ -17618,6 +18012,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/qs-stringify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/qs-stringify/-/qs-stringify-1.2.1.tgz",
+      "integrity": "sha512-2N5xGLGZUxpgAYq1fD1LmBSCbxQVsXYt5JU0nU3FuPWO8PlCnKNFQwXkZgyB6mrTdg7IbexX4wxIR403dJw9pw=="
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -19101,7 +19500,6 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/sshpk": {
@@ -20454,6 +20852,45 @@
         "node": "*"
       }
     },
+    "node_modules/tus-js-client": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-1.8.0.tgz",
+      "integrity": "sha512-qPX3TywqzxocTxUZtcS8X7Aik72SVMa0jKi4hWyfvRV+s9raVzzYGaP4MoJGaF0yOgm2+b6jXaVEHogxcJ8LGw==",
+      "dependencies": {
+        "buffer-from": "^0.1.1",
+        "combine-errors": "^3.0.3",
+        "extend": "^3.0.2",
+        "js-base64": "^2.4.9",
+        "lodash.throttle": "^4.1.1",
+        "proper-lockfile": "^2.0.1",
+        "url-parse": "^1.4.3"
+      }
+    },
+    "node_modules/tus-js-client/node_modules/buffer-from": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+    },
+    "node_modules/tus-js-client/node_modules/proper-lockfile": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-2.0.1.tgz",
+      "integrity": "sha512-rjaeGbsmhNDcDInmwi4MuI6mRwJu6zq8GjYCLuSuE7GF+4UjgzkL69sVKKJ2T2xH61kK7rXvGYpvaTu909oXaQ==",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "retry": "^0.10.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/tus-js-client/node_modules/retry": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha512-ZXUSQYTHdl3uS7IuCehYfMzKyIDBNoAuUblvy5oGO5UJSUTmStUUVPXbA9Qxd173Bgre53yCQczQuHgRWAdvJQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "license": "Unlicense"
@@ -21077,6 +21514,11 @@
       "dependencies": {
         "bs58check": "<3.0.0"
       }
+    },
+    "node_modules/wildcard": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-1.1.2.tgz",
+      "integrity": "sha512-DXukZJxpHA8LuotRwL0pP1+rS6CS7FF2qStDDE1C7DDg2rLud2PXRMuEDYIPhgEezwnlHNL4c+N6MfMTjCGTng=="
     },
     "node_modules/winston": {
       "version": "3.3.3",
@@ -23018,9 +23460,74 @@
     "@types/retry": {
       "version": "0.12.0"
     },
+    "@types/tus-js-client": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@types/tus-js-client/-/tus-js-client-1.8.0.tgz",
+      "integrity": "sha512-lWxu5+6qfyfwsW99GzUeJ9y9JeOSSLduKxgYMvaYM7sGTDKZsrIIHTUbHI2P016xhXtu9NxmUM3GrB4i14ie4A=="
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "dev": true
+    },
+    "@uppy/companion-client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@uppy/companion-client/-/companion-client-1.10.2.tgz",
+      "integrity": "sha512-5RmsNF9UBvUqmqQz48SoiLvkpGmvQTgwNM4bJX8xwVozv/6goRpFrsMJGLwqFcHS/9xj6STKOqrM582g8exVwQ==",
+      "requires": {
+        "@uppy/utils": "^3.6.2",
+        "namespace-emitter": "^2.0.1",
+        "qs-stringify": "^1.1.0",
+        "url-parse": "^1.4.7"
+      },
+      "dependencies": {
+        "@uppy/utils": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/@uppy/utils/-/utils-3.6.2.tgz",
+          "integrity": "sha512-wGTZma7eywIojfuE1vXlT0fxPSpmCRMkfgFWYc+6TL2FfGqWInmePoB+yal6/M2AnjeKHz6XYMhIpZkjOxFvcw==",
+          "requires": {
+            "abortcontroller-polyfill": "^1.4.0",
+            "lodash.throttle": "^4.1.1"
+          }
+        }
+      }
+    },
+    "@uppy/core": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@uppy/core/-/core-1.10.4.tgz",
+      "integrity": "sha512-mORSXL4JyXHGo98u6u0sMzv3wtdI5jjHsqyThQAXx3LvctWE0EBrxE7vJqrXue2z/m9lovsZVhuzP2L7Qkuebg==",
+      "requires": {
+        "@uppy/store-default": "^1.2.1",
+        "@uppy/utils": "^2.4.4",
+        "cuid": "^2.1.1",
+        "lodash.throttle": "^4.1.1",
+        "mime-match": "^1.0.2",
+        "namespace-emitter": "^2.0.1",
+        "preact": "8.2.9"
+      }
+    },
+    "@uppy/store-default": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@uppy/store-default/-/store-default-1.2.7.tgz",
+      "integrity": "sha512-58IG9yk/i/kYQ9uEwAwMFl1H2V3syOoODrYoFfVHlxaqv+9MkXBg2tHE2gk40iaAIxcCErcPxZkBOvkqzO1SQA=="
+    },
+    "@uppy/tus": {
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@uppy/tus/-/tus-1.5.12.tgz",
+      "integrity": "sha512-jDiwsTRHnMfb83ZB8JdDD0uA9DX0K/FqenGMYBGTOlkCjAcXD3sI59DzEHwq2TtY3ZH7iaL3fTNQ7ExBWkwrqw==",
+      "requires": {
+        "@types/tus-js-client": "^1.8.0",
+        "@uppy/companion-client": "^1.4.4",
+        "@uppy/utils": "^2.4.4",
+        "tus-js-client": "^1.8.0"
+      }
+    },
+    "@uppy/utils": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@uppy/utils/-/utils-2.4.4.tgz",
+      "integrity": "sha512-7A0uwK5Rf8XcKqlpNUZ5L5LmkHT5c0/UWjDJGwmzeCxp2lECgzsMC+4vgA6kT4sFzPFbLtUtxHi7ecFwow3NQQ==",
+      "requires": {
+        "lodash.throttle": "^4.1.1"
+      }
     },
     "@vascosantos/moving-average": {
       "version": "1.1.0"
@@ -23164,6 +23671,11 @@
       "requires": {
         "get-iterator": "^1.0.2"
       }
+    },
+    "abortcontroller-polyfill": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
+      "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q=="
     },
     "abstract-leveldown": {
       "version": "7.2.0",
@@ -23321,6 +23833,32 @@
         }
       }
     },
+    "apidoc-core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/apidoc-core/-/apidoc-core-0.12.0.tgz",
+      "integrity": "sha512-VMhkJWz5IAyvWM0RnEbKNi1qe8se+id3/Ki3H/ePM8ih0KYTfaaSDxqo2w4uIVB1UVVKFvrTWyYUyQs7CEcoKQ==",
+      "requires": {
+        "fs-extra": "^9.0.1",
+        "glob": "^7.1.6",
+        "iconv-lite": "^0.6.2",
+        "klaw-sync": "^6.0.0",
+        "lodash": "^4.17.20",
+        "semver": "~7.3.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
+    },
     "append-transform": {
       "version": "2.0.0",
       "dev": true,
@@ -23344,7 +23882,6 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -23492,6 +24029,11 @@
     },
     "asynckit": {
       "version": "0.4.0"
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atomic-sleep": {
       "version": "1.0.0"
@@ -24295,6 +24837,26 @@
         "text-hex": "1.0.x"
       }
     },
+    "combine-errors": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/combine-errors/-/combine-errors-3.0.3.tgz",
+      "integrity": "sha512-C8ikRNRMygCwaTx+Ek3Yr+OuZzgZjduCOfSQBjbM8V3MfgcjSTeto/GXP6PAwKvJz/v15b7GHZvx5rOlczFw/Q==",
+      "requires": {
+        "custom-error-instance": "2.1.1",
+        "lodash.uniqby": "4.5.0"
+      },
+      "dependencies": {
+        "lodash.uniqby": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.5.0.tgz",
+          "integrity": "sha512-IRt7cfTtHy6f1aRVA5n7kT8rgN3N1nH6MOWLcHfpWG2SH19E3JksLK38MktLxZDhlAjCP9jpIXkOnRXlu6oByQ==",
+          "requires": {
+            "lodash._baseiteratee": "~4.7.0",
+            "lodash._baseuniq": "~4.6.0"
+          }
+        }
+      }
+    },
     "combined-stream": {
       "version": "1.0.8",
       "requires": {
@@ -24553,6 +25115,16 @@
     },
     "crypto-random-string": {
       "version": "2.0.0"
+    },
+    "cuid": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg=="
+    },
+    "custom-error-instance": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/custom-error-instance/-/custom-error-instance-2.1.1.tgz",
+      "integrity": "sha512-p6JFxJc3M4OTD2li2qaHkDCw9SfMw82Ldr6OC9Je1aXiGfhx2W8p3GaoeaGrPJTUN9NirTM/KTxHWMUdR1rsUg=="
     },
     "d64": {
       "version": "1.0.0"
@@ -27937,6 +28509,11 @@
     "jquery": {
       "version": "3.6.0"
     },
+    "js-base64": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+    },
     "js-sha256": {
       "version": "0.9.0"
     },
@@ -28911,6 +29488,46 @@
     "lodash": {
       "version": "4.17.21"
     },
+    "lodash._baseiteratee": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz",
+      "integrity": "sha512-nqB9M+wITz0BX/Q2xg6fQ8mLkyfF7MU7eE+MNBNjTHFKeKaZAPEzEg+E8LWxKWf1DQVflNEn9N49yAuqKh2mWQ==",
+      "requires": {
+        "lodash._stringtopath": "~4.8.0"
+      }
+    },
+    "lodash._basetostring": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
+      "integrity": "sha512-SwcRIbyxnN6CFEEK4K1y+zuApvWdpQdBHM/swxP962s8HIxPO3alBH5t3m/dl+f4CMUug6sJb7Pww8d13/9WSw=="
+    },
+    "lodash._baseuniq": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+      "integrity": "sha512-Ja1YevpHZctlI5beLA7oc5KNDhGcPixFhcqSiORHNsp/1QTv7amAXzw+gu4YOvErqVlMVyIJGgtzeepCnnur0A==",
+      "requires": {
+        "lodash._createset": "~4.0.0",
+        "lodash._root": "~3.0.0"
+      }
+    },
+    "lodash._createset": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+      "integrity": "sha512-GTkC6YMprrJZCYU3zcqZj+jkXkrXzq3IPBcF/fIPpNEAB4hZEtXU8zp/RwKOvZl43NUmwDbyRk3+ZTbeRdEBXA=="
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha512-O0pWuFSK6x4EXhM1dhZ8gchNtG7JMqBtrHdoUFUWXD7dJnNSUze1GuyQr5sOs0aCvgGeI3o/OJW8f4ca7FDxmQ=="
+    },
+    "lodash._stringtopath": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/lodash._stringtopath/-/lodash._stringtopath-4.8.0.tgz",
+      "integrity": "sha512-SXL66C731p0xPDC5LZg4wI5H+dJo/EO4KTqOMwLYCH3+FmmfAKJEZCm6ohGpI+T1xwsDsJCfL4OnhorllvlTPQ==",
+      "requires": {
+        "lodash._basetostring": "~4.12.0"
+      }
+    },
     "lodash.camelcase": {
       "version": "4.3.0"
     },
@@ -29161,6 +29778,14 @@
     },
     "mime-db": {
       "version": "1.52.0"
+    },
+    "mime-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mime-match/-/mime-match-1.0.2.tgz",
+      "integrity": "sha512-VXp/ugGDVh3eCLOBCiHZMYWQaTNUHv2IJrut+yXA6+JbLPXHglHwfS/5A5L0ll+jkCY7fIzRJcH6OIunF+c6Cg==",
+      "requires": {
+        "wildcard": "^1.1.0"
+      }
     },
     "mime-types": {
       "version": "2.1.35",
@@ -29691,6 +30316,11 @@
     },
     "mutable-proxy": {
       "version": "1.0.0"
+    },
+    "namespace-emitter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/namespace-emitter/-/namespace-emitter-2.0.1.tgz",
+      "integrity": "sha512-N/sMKHniSDJBjfrkbS/tpkPj4RAbvW3mr8UAzvlMHyun93XEm83IAvhWtJVHo+RHn/oO8Job5YN4b+wRjSVp5g=="
     },
     "nan": {
       "version": "2.15.0"
@@ -32548,6 +33178,195 @@
     "p-whilst": {
       "version": "2.1.0"
     },
+    "p2wdb": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/p2wdb/-/p2wdb-1.4.0.tgz",
+      "integrity": "sha512-YbwxKdaT8yKvE+vEGJYfOdquASOgYY0C4OP7h4jd8ceHg5w+dxUnPrjAF2ll7fXx02y2vPndAKgSBStvBYZL/A==",
+      "requires": {
+        "apidoc": "0.25.0",
+        "axios": "0.24.0",
+        "minimal-slp-wallet": "4.4.2"
+      },
+      "dependencies": {
+        "@psf/bch-js": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/@psf/bch-js/-/bch-js-5.3.2.tgz",
+          "integrity": "sha512-LzYekwuee+T8AEZ1MKBe5KnZKXzpRZ57SpXRL2S8qsHefokTIN+XnDPX7dsOFkN4VGGgyjYyZ33iN6xhOSHWJw==",
+          "requires": {
+            "@chris.troutner/bip32-utils": "1.0.5",
+            "@psf/bip21": "2.0.1",
+            "@psf/bitcoincash-ops": "2.0.0",
+            "@psf/bitcoincashjs-lib": "4.0.2",
+            "@psf/coininfo": "4.0.0",
+            "@uppy/core": "1.10.4",
+            "@uppy/tus": "1.5.12",
+            "axios": "^0.21.4",
+            "bc-bip68": "1.0.5",
+            "bchaddrjs-slp": "0.2.5",
+            "bigi": "1.4.2",
+            "bignumber.js": "9.0.0",
+            "bip-schnorr": "0.3.0",
+            "bip38": "2.0.2",
+            "bip39": "3.0.2",
+            "bip66": "1.1.5",
+            "bitcoinjs-message": "2.0.0",
+            "bs58": "4.0.1",
+            "ecashaddrjs": "1.0.7",
+            "ini": "1.3.8",
+            "randombytes": "2.0.6",
+            "safe-buffer": "5.1.2",
+            "satoshi-bitcoin": "1.0.4",
+            "slp-mdm": "0.0.6",
+            "slp-parser": "0.0.4",
+            "wif": "2.0.6"
+          },
+          "dependencies": {
+            "axios": {
+              "version": "0.21.4",
+              "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+              "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+              "requires": {
+                "follow-redirects": "^1.14.0"
+              }
+            }
+          }
+        },
+        "apidoc": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.25.0.tgz",
+          "integrity": "sha512-5g9fp8OffXZOdBTzm4BBvV5Vw54s+NmKnGZIUKuH+gRTqqJuRJpcGN6sz6WnjJ+NcvXhB7rIRp6FhtJahazx2Q==",
+          "requires": {
+            "apidoc-core": "^0.12.0",
+            "commander": "^2.20.0",
+            "fs-extra": "^9.0.1",
+            "handlebars": "^4.7.6",
+            "lodash": "^4.17.20",
+            "markdown-it": "^11.0.0",
+            "nodemon": "^2.0.4",
+            "winston": "^3.3.3"
+          }
+        },
+        "axios": {
+          "version": "0.24.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        },
+        "bch-consumer": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/bch-consumer/-/bch-consumer-1.2.0.tgz",
+          "integrity": "sha512-RzoJXA95OkXaV4MFAB1wFjdEsn9lmBO7F5lptUMswmpMhyRKhgfKN9m3+gN1Qj9Kiq66YTU2b2EcUlf1Iw1ETA==",
+          "requires": {
+            "@psf/bch-js": "5.3.1",
+            "apidoc": "0.25.0",
+            "axios": "0.25.0"
+          },
+          "dependencies": {
+            "@psf/bch-js": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/@psf/bch-js/-/bch-js-5.3.1.tgz",
+              "integrity": "sha512-HoeRM7q+zsTLIqifweEntFDHG35cL0Ps7nnh59CDbBsswpgWcvhPxBmgsHcf9m9SdHsTzHaNgX2WQuYw8nl0bg==",
+              "requires": {
+                "@chris.troutner/bip32-utils": "1.0.5",
+                "@psf/bip21": "2.0.1",
+                "@psf/bitcoincash-ops": "2.0.0",
+                "@psf/bitcoincashjs-lib": "4.0.2",
+                "@psf/coininfo": "4.0.0",
+                "@uppy/core": "1.10.4",
+                "@uppy/tus": "1.5.12",
+                "axios": "^0.21.4",
+                "bc-bip68": "1.0.5",
+                "bchaddrjs-slp": "0.2.5",
+                "bigi": "1.4.2",
+                "bignumber.js": "9.0.0",
+                "bip-schnorr": "0.3.0",
+                "bip38": "2.0.2",
+                "bip39": "3.0.2",
+                "bip66": "1.1.5",
+                "bitcoinjs-message": "2.0.0",
+                "bs58": "4.0.1",
+                "ecashaddrjs": "1.0.7",
+                "ini": "1.3.8",
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.2",
+                "satoshi-bitcoin": "1.0.4",
+                "slp-mdm": "0.0.6",
+                "slp-parser": "0.0.4",
+                "wif": "2.0.6"
+              },
+              "dependencies": {
+                "axios": {
+                  "version": "0.21.4",
+                  "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+                  "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+                  "requires": {
+                    "follow-redirects": "^1.14.0"
+                  }
+                }
+              }
+            },
+            "axios": {
+              "version": "0.25.0",
+              "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+              "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+              "requires": {
+                "follow-redirects": "^1.14.7"
+              }
+            }
+          }
+        },
+        "bch-donation": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/bch-donation/-/bch-donation-1.1.1.tgz",
+          "integrity": "sha512-FDfBlzKoswbpGQHfRez4eddgOdWfWiZPGLZsCNxwxn98LDnykPGJdmDmtg2Gn8ogCvLLTilEolY0YFKwlx+yEg==",
+          "requires": {
+            "apidoc": "^0.25.0"
+          }
+        },
+        "entities": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "markdown-it": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-11.0.1.tgz",
+          "integrity": "sha512-aU1TzmBKcWNNYvH9pjq6u92BML+Hz3h5S/QpfTFwiQF852pLT+9qHsrhM9JYipkOXZxGn+sGH8oyJE9FD9WezQ==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "entities": "~2.0.0",
+            "linkify-it": "^3.0.1",
+            "mdurl": "^1.0.1",
+            "uc.micro": "^1.0.5"
+          }
+        },
+        "minimal-slp-wallet": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/minimal-slp-wallet/-/minimal-slp-wallet-4.4.2.tgz",
+          "integrity": "sha512-6JNRnH8mQQb/gmfwdd0KgJeHFJycK60EDmeEdjghvm1I2J0z2HVI3gZzrVqjBC/tBDYKtuDuvRtix7q2LqKqhw==",
+          "requires": {
+            "@psf/bch-js": "5.3.2",
+            "apidoc": "0.25.0",
+            "bch-consumer": "1.2.0",
+            "bch-donation": "1.1.1",
+            "crypto-js": "4.0.0"
+          }
+        }
+      }
+    },
     "package-hash": {
       "version": "4.0.0",
       "dev": true,
@@ -32956,6 +33775,11 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "preact": {
+      "version": "8.2.9",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.9.tgz",
+      "integrity": "sha512-ThuGXBmJS3VsT+jIP+eQufD3L8pRw/PY3FoCys6O9Pu6aF12Pn9zAJDX99TfwRAFOCEKm/P0lwiPTbqKMJp0fA=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "dev": true
@@ -33296,6 +34120,11 @@
       "requires": {
         "side-channel": "^1.0.4"
       }
+    },
+    "qs-stringify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/qs-stringify/-/qs-stringify-1.2.1.tgz",
+      "integrity": "sha512-2N5xGLGZUxpgAYq1fD1LmBSCbxQVsXYt5JU0nU3FuPWO8PlCnKNFQwXkZgyB6mrTdg7IbexX4wxIR403dJw9pw=="
     },
     "querystringify": {
       "version": "2.2.0"
@@ -34281,8 +35110,7 @@
       }
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
     "sshpk": {
       "version": "1.17.0",
@@ -35181,6 +36009,41 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "tus-js-client": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-1.8.0.tgz",
+      "integrity": "sha512-qPX3TywqzxocTxUZtcS8X7Aik72SVMa0jKi4hWyfvRV+s9raVzzYGaP4MoJGaF0yOgm2+b6jXaVEHogxcJ8LGw==",
+      "requires": {
+        "buffer-from": "^0.1.1",
+        "combine-errors": "^3.0.3",
+        "extend": "^3.0.2",
+        "js-base64": "^2.4.9",
+        "lodash.throttle": "^4.1.1",
+        "proper-lockfile": "^2.0.1",
+        "url-parse": "^1.4.3"
+      },
+      "dependencies": {
+        "buffer-from": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+        },
+        "proper-lockfile": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-2.0.1.tgz",
+          "integrity": "sha512-rjaeGbsmhNDcDInmwi4MuI6mRwJu6zq8GjYCLuSuE7GF+4UjgzkL69sVKKJ2T2xH61kK7rXvGYpvaTu909oXaQ==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "retry": "^0.10.0"
+          }
+        },
+        "retry": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+          "integrity": "sha512-ZXUSQYTHdl3uS7IuCehYfMzKyIDBNoAuUblvy5oGO5UJSUTmStUUVPXbA9Qxd173Bgre53yCQczQuHgRWAdvJQ=="
+        }
+      }
+    },
     "tweetnacl": {
       "version": "0.14.5"
     },
@@ -35586,6 +36449,11 @@
       "requires": {
         "bs58check": "<3.0.0"
       }
+    },
+    "wildcard": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-1.1.2.tgz",
+      "integrity": "sha512-DXukZJxpHA8LuotRwL0pP1+rS6CS7FF2qStDDE1C7DDg2rLud2PXRMuEDYIPhgEezwnlHNL4c+N6MfMTjCGTng=="
     },
     "winston": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "node-fetch": "npm:@achingbrain/node-fetch@2.6.7",
     "nodemailer": "6.7.5",
     "orbit-db": "0.28.0",
+    "p2wdb": "1.4.0",
     "passport-local": "1.0.0",
     "public-ip": "4.0.4",
     "winston": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "koa-static": "5.0.0",
     "koa2-ratelimit": "0.9.1",
     "line-reader": "0.4.0",
-    "minimal-slp-wallet": "4.6.5",
+    "minimal-slp-wallet": "5.0.0",
     "mongoose": "5.13.14",
     "node-fetch": "npm:@achingbrain/node-fetch@2.6.7",
     "nodemailer": "6.7.5",

--- a/production/scripts/create-wallet.js
+++ b/production/scripts/create-wallet.js
@@ -1,0 +1,32 @@
+/*
+  Generate a wallet.json file for use with the DEX.
+*/
+
+// Public NPM libraries
+const BchWallet = require('minimal-slp-wallet/index')
+const fs = require('fs').promises
+
+async function createWallet () {
+  try {
+    // Configure the minimal-slp-wallet library to use the JSON RPC over IPFS.
+    const advancedConfig = {
+      interface: 'consumer-api',
+      noUpdate: true
+    }
+
+    // Wait for the wallet to be created.
+    this.bchWallet = new BchWallet(undefined, advancedConfig)
+    await this.bchWallet.walletInfoPromise
+    const walletData = this.bchWallet.walletInfo
+    walletData.nextAddress = 1
+
+    // Save the wallet file to disk.
+    await fs.writeFile('../../wallet.json', JSON.stringify(walletData, null, 2))
+
+    console.log('Generated wallet.json. Copy this file to the docker/bch-dex folder to be used inside the Docker container.')
+    console.log(`${JSON.stringify(walletData, null, 2)}`)
+  } catch (err) {
+    console.error('Error: ', err)
+  }
+}
+createWallet()

--- a/shell-scripts/local-external-ipfs-node.sh
+++ b/shell-scripts/local-external-ipfs-node.sh
@@ -29,4 +29,7 @@ export IPFS_TCP_PORT=4001
 export P2W_ENV=production
 export DBURL=mongodb://localhost:27017/p2wdb-service-dev
 
+# Enable BCH payments for P2WDB writes
+export ENABLE_BCH_PAYMENT=1
+
 npm start

--- a/src/adapters/index.js
+++ b/src/adapters/index.js
@@ -20,6 +20,7 @@ const P2WDB = require('./p2wdb')
 const EntryAdapter = require('./entry')
 const WebhookAdapter = require('./webhook')
 const WritePrice = require('./write-price')
+const Wallet = require('./wallet')
 
 const config = require('../../config')
 
@@ -37,6 +38,7 @@ class Adapters {
     this.entry = new EntryAdapter()
     this.webhook = new WebhookAdapter()
     this.writePrice = new WritePrice()
+    this.wallet = new Wallet()
 
     // Pass the instance of write-price when instantiating the P2WDB OrbitDB.
     localConfig.writePrice = this.writePrice
@@ -66,10 +68,15 @@ class Adapters {
         const currentRate = this.writePrice.getCurrentCostPSF()
         console.log(`Current P2WDB cost is ${currentRate} PSF tokens per write.`)
 
-        // Retrieve the cost of a write in BCH, if that feature is enabled.
+        // Only execute the code in this block if BCH payments are enabled.
         if (this.config.enableBchPayment) {
+          // Retrieve the cost of a write in BCH, if that feature is enabled.
           const bchRate = await this.writePrice.getWriteCostInBch()
           console.log(`BCH payments enabled. Current P2WDB cost is ${bchRate} BCH per write.`)
+
+          // Instance the wallet.
+          const walletData = await this.wallet.openWallet()
+          await this.wallet.instanceWallet(walletData)
         }
 
         // Start the IPFS node.

--- a/src/adapters/index.js
+++ b/src/adapters/index.js
@@ -66,6 +66,12 @@ class Adapters {
         const currentRate = this.writePrice.getCurrentCostPSF()
         console.log(`Current P2WDB cost is ${currentRate} PSF tokens per write.`)
 
+        // Retrieve the cost of a write in BCH, if that feature is enabled.
+        if (this.config.enableBchPayment) {
+          const bchRate = await this.writePrice.getWriteCostInBch()
+          console.log(`BCH payments enabled. Current P2WDB cost is ${bchRate} BCH per write.`)
+        }
+
         // Start the IPFS node.
         await this.ipfs.start({ bchjs: this.bchjs })
 

--- a/src/adapters/json-files.js
+++ b/src/adapters/json-files.js
@@ -52,12 +52,13 @@ class JsonFiles {
         _this.fs.readFile(fileName, (err, data) => {
           if (err) {
             if (err.code === 'ENOENT') {
-              console.log('Admin .json file not found!')
+              console.log('.json file not found!')
             } else {
               console.log(`err: ${JSON.stringify(err, null, 2)}`)
             }
 
-            throw err
+            // throw err
+            return reject(err)
           }
 
           const obj = JSON.parse(data)

--- a/src/adapters/localdb/index.js
+++ b/src/adapters/localdb/index.js
@@ -4,11 +4,13 @@
 
 // Load Mongoose models.
 const Users = require('./models/users')
+const BchPayment = require('./models/bch-payment')
 
 class LocalDB {
   constructor () {
     // Encapsulate dependencies
     this.Users = Users
+    this.BchPayment = BchPayment
   }
 }
 

--- a/src/adapters/localdb/models/bch-payment.js
+++ b/src/adapters/localdb/models/bch-payment.js
@@ -1,0 +1,14 @@
+/*
+  This model is used to track BCH Payments for writing to the P2WDB.
+*/
+
+const mongoose = require('mongoose')
+
+const BchPayment = new mongoose.Schema({
+  address: { type: String, required: true },
+  bchCost: { type: String, required: true },
+  timeCreated: { type: String },
+  hdIndex: { type: String, required: true }
+})
+
+module.exports = mongoose.model('bchPayment', BchPayment)

--- a/src/adapters/wallet.js
+++ b/src/adapters/wallet.js
@@ -89,6 +89,9 @@ class WalletAdapter {
       console.log(`BCH wallet initialized. Wallet address: ${this.bchWallet.walletInfo.cashAddress}`)
       // console.log(`this.bchWallet.walletInfo: ${JSON.stringify(this.bchWallet.walletInfo, null, 2)}`)
 
+      // Initialize the wallet
+      await this.bchWallet.initialize()
+
       return this.bchWallet
     } catch (err) {
       console.error('Error in instanceWallet()')

--- a/src/adapters/wallet.js
+++ b/src/adapters/wallet.js
@@ -1,0 +1,167 @@
+/*
+  Adapter library for working with a wallet.
+*/
+
+// Public npm libraries
+const BchWallet = require('minimal-slp-wallet/index')
+
+// Local libraries
+const JsonFiles = require('./json-files')
+const config = require('../../config')
+
+const WALLET_FILE = `${__dirname.toString()}/../../wallet.json`
+
+class WalletAdapter {
+  constructor (localConfig = {}) {
+    // Encapsulate dependencies
+    this.jsonFiles = new JsonFiles()
+    this.WALLET_FILE = WALLET_FILE
+    this.BchWallet = BchWallet
+    this.config = config
+  }
+
+  // Open the wallet file, or create one if the file doesn't exist.
+  // Does not instance the wallet. The output of this function is expected to
+  // be passed to instanceWallet().
+  async openWallet () {
+    try {
+      let walletData
+
+      // Try to open the wallet.json file.
+      try {
+        // console.log('this.WALLET_FILE: ', this.WALLET_FILE)
+        walletData = await this.jsonFiles.readJSON(this.WALLET_FILE)
+      } catch (err) {
+        // Create a new wallet file if one does not already exist.
+        console.log('Wallet file not found. Creating new wallet.json file.')
+
+        // Create a new wallet.
+        // No-Update flag creates wallet without making any network calls.
+        const walletInstance = new this.BchWallet(undefined, { noUpdate: true })
+
+        // Wait for wallet to initialize.
+        await walletInstance.walletInfoPromise
+
+        walletData = walletInstance.walletInfo
+
+        // Add the nextAddress property
+        walletData.nextAddress = 1
+
+        // Write the wallet data to the JSON file.
+        await this.jsonFiles.writeJSON(walletData, this.WALLET_FILE)
+      }
+
+      // console.log('walletData: ', walletData)
+
+      return walletData
+    } catch (err) {
+      console.error('Error in openWallet()')
+      throw err
+    }
+  }
+
+  // Create an instance of minimal-slp-wallet. Use data in the wallet.json file,
+  // and pass the bch-js information to the minimal-slp-wallet library.
+  async instanceWallet (walletData) {
+    try {
+      // console.log(`instanceWallet() walletData: ${JSON.stringify(walletData, null, 2)}`)
+
+      // TODO: throw error if wallet data is not passed in.
+      if (!walletData.mnemonic) {
+        throw new Error('Wallet data is not formatted correctly. Can not read mnemonic in wallet file!')
+      }
+
+      const advancedConfig = {}
+      if (this.config.useFullStackCash) {
+        advancedConfig.interface = 'rest-api'
+        advancedConfig.restURL = this.config.apiServer
+        advancedConfig.apiToken = this.config.apiToken
+      } else {
+        advancedConfig.interface = 'consumer-api'
+        advancedConfig.restURL = this.config.consumerUrl
+      }
+
+      // Instantiate minimal-slp-wallet.
+      this.bchWallet = new this.BchWallet(walletData.mnemonic, advancedConfig)
+
+      // Wait for wallet to initialize.
+      await this.bchWallet.walletInfoPromise
+      console.log(`BCH wallet initialized. Wallet address: ${this.bchWallet.walletInfo.cashAddress}`)
+      // console.log(`this.bchWallet.walletInfo: ${JSON.stringify(this.bchWallet.walletInfo, null, 2)}`)
+
+      return this.bchWallet
+    } catch (err) {
+      console.error('Error in instanceWallet()')
+      throw err
+    }
+  }
+
+  // Increments the 'nextAddress' property in the wallet file. This property
+  // indicates the HD index that should be used to generate a key pair for
+  // storing funds for Offers.
+  // This function opens the wallet file, increments the nextAddress property,
+  // then saves the change to the wallet file.
+  async incrementNextAddress () {
+    try {
+      const walletData = await this.openWallet()
+      // console.log('original walletdata: ', walletData)
+
+      walletData.nextAddress++
+
+      // console.log('walletData finish: ', walletData)
+      await this.jsonFiles.writeJSON(walletData, this.WALLET_FILE)
+
+      // Update the working instance of the wallet.
+      this.bchWallet.walletInfo.nextAddress++
+      // console.log('this.bchWallet.walletInfo: ', this.bchWallet.walletInfo)
+
+      return walletData.nextAddress
+    } catch (err) {
+      console.error('Error in incrementNextAddress()')
+      throw err
+    }
+  }
+
+  // This method returns an object that contains a private key WIF, public address,
+  // and the index of the HD wallet that the key pair was generated from.
+  // TODO: Allow input integer. If input is used, use that as the index. If no
+  // input is provided, then call incrementNextAddress().
+  async getKeyPair (hdIndex = 0) {
+    try {
+      if (!hdIndex) {
+        // Increment the HD index and generate a new key pair.
+        hdIndex = await this.incrementNextAddress()
+      }
+
+      const mnemonic = this.bchWallet.walletInfo.mnemonic
+
+      // root seed buffer
+      const rootSeed = await this.bchWallet.bchjs.Mnemonic.toSeed(mnemonic)
+
+      const masterHDNode = this.bchWallet.bchjs.HDNode.fromSeed(rootSeed)
+
+      // HDNode of BIP44 account
+      // const account = this.bchWallet.bchjs.HDNode.derivePath(masterHDNode, "m/44'/245'/0'")
+
+      const childNode = masterHDNode.derivePath(`m/44'/245'/0'/0/${hdIndex}`)
+
+      const cashAddress = this.bchWallet.bchjs.HDNode.toCashAddress(childNode)
+      console.log('Generating a new key pair for cashAddress: ', cashAddress)
+
+      const wif = this.bchWallet.bchjs.HDNode.toWIF(childNode)
+
+      const outObj = {
+        cashAddress,
+        wif,
+        hdIndex
+      }
+
+      return outObj
+    } catch (err) {
+      console.error('Error in getKeyPair()')
+      throw err
+    }
+  }
+}
+
+module.exports = WalletAdapter

--- a/src/adapters/wallet.js
+++ b/src/adapters/wallet.js
@@ -82,12 +82,13 @@ class WalletAdapter {
       }
 
       // Instantiate minimal-slp-wallet.
-      this.bchWallet = new this.BchWallet(walletData.mnemonic, advancedConfig)
+      // this.bchWallet = new this.BchWallet(walletData.mnemonic, advancedConfig)
+      this.bchWallet = await this._instanceWallet(walletData.mnemonic, advancedConfig)
 
       // Wait for wallet to initialize.
       await this.bchWallet.walletInfoPromise
       console.log(`BCH wallet initialized. Wallet address: ${this.bchWallet.walletInfo.cashAddress}`)
-      // console.log(`this.bchWallet.walletInfo: ${JSON.stringify(this.bchWallet.walletInfo, null, 2)}`)
+      console.log(`this.bchWallet.walletInfo: ${JSON.stringify(this.bchWallet.walletInfo, null, 2)}`)
 
       // Initialize the wallet
       await this.bchWallet.initialize()
@@ -97,6 +98,13 @@ class WalletAdapter {
       console.error('Error in instanceWallet()')
       throw err
     }
+  }
+
+  // This function is used for easier mocking of unit tests.
+  async _instanceWallet (mnemonic, config) {
+    const wallet = new this.BchWallet(mnemonic, config)
+    await wallet.walletInfoPromise
+    return wallet
   }
 
   // Increments the 'nextAddress' property in the wallet file. This property

--- a/src/adapters/write-price.js
+++ b/src/adapters/write-price.js
@@ -157,6 +157,39 @@ class WritePrice {
       throw err
     }
   }
+
+  // Get's the cost of PSF tokens in BCH from the PSF token liquidity app.
+  // This value is used to allow users to pay in BCH, and enables the P2WDB
+  // to essentailly exchange a PSF tokens for BCH, in order to write to the DB.
+  async getPsfPriceInBch () {
+    try {
+      const response = await this.axios.get('https://psfoundation.cash/price')
+      // console.log('response.data: ', response.data)
+
+      const usdPerBch = response.data.usdPerBCH
+      const usdPerToken = response.data.usdPerToken
+
+      const bchPerToken = this.bchjs.Util.floor8(usdPerToken / usdPerBch)
+      // console.log('bchPerToken: ', bchPerToken)
+
+      return bchPerToken
+    } catch (err) {
+      console.error('Error in adapters/write-price.js/getPsfPrice(): ', err)
+      throw err
+    }
+  }
+
+  // This function calls getPsfPrice() to get the price of PSF tokens in BCH.
+  // It then calculates and returns the cost to write to the P2WDB in BCH.
+  // That includes a markup cost for the service of providing PSF tokens to
+  // the user. The market cost is set in the config file.
+  async getWriteCostInBch () {
+    const bchPerToken = await this.getPsfPriceInBch()
+
+    const costToUser = this.currentRate * bchPerToken * (1 + this.config.psfTradeMarkup)
+
+    return this.bchjs.Util.floor8(costToUser)
+  }
 }
 
 module.exports = WritePrice

--- a/src/adapters/write-price.js
+++ b/src/adapters/write-price.js
@@ -26,6 +26,7 @@ class WritePrice {
 
     // state
     this.currentRate = 0.133
+    this.currentRateInBch = 0.0001
     this.priceHistory = []
   }
 
@@ -186,9 +187,16 @@ class WritePrice {
   async getWriteCostInBch () {
     const bchPerToken = await this.getPsfPriceInBch()
 
-    const costToUser = this.currentRate * bchPerToken * (1 + this.config.psfTradeMarkup)
+    // Cost in BCH + markup.
+    let costToUser = this.currentRate * bchPerToken * (1 + this.config.psfTradeMarkup)
 
-    return this.bchjs.Util.floor8(costToUser)
+    // Round to 8 decimals.
+    costToUser = this.bchjs.Util.floor8(costToUser)
+
+    // Save to state.
+    this.currentRateInBch = costToUser
+
+    return costToUser
   }
 }
 

--- a/src/controllers/rest-api/entry/index.js
+++ b/src/controllers/rest-api/entry/index.js
@@ -52,6 +52,7 @@ class EntryController {
     }
 
     // Define the routes and attach the controller.
+    this.router.post('/write/bch', this.postBchEntry)
     this.router.post('/write', this.postEntry)
     this.router.get('/all/:page', this.readAllEntries)
     this.router.get('/hash/:hash', this.getByHash)
@@ -70,6 +71,11 @@ class EntryController {
   async postEntry (ctx, next) {
     // await _this.validators.ensureUser(ctx, next)
     await _this.entryRESTController.postEntry(ctx, next)
+  }
+
+  async postBchEntry (ctx, next) {
+    // await _this.validators.ensureUser(ctx, next)
+    await _this.entryRESTController.postBchEntry(ctx, next)
   }
 
   async readAllEntries (ctx, next) {

--- a/src/controllers/rest-api/entry/index.js
+++ b/src/controllers/rest-api/entry/index.js
@@ -59,6 +59,7 @@ class EntryController {
     this.router.get('/appid/:appid', this.getByAppId)
     this.router.get('/cost/psf', this.getPsfCost)
     this.router.post('/cost/psf', this.getPsfCostTarget)
+    this.router.get('/cost/bch', this.getBchCost)
 
     // Attach the Controller routes to the Koa app.
     app.use(cors({ origin: '*' }))
@@ -99,6 +100,11 @@ class EntryController {
   async getPsfCostTarget (ctx, next) {
     // await _this.validators.ensureUser(ctx, next)
     await _this.entryRESTController.getPsfCostTarget(ctx, next)
+  }
+
+  async getBchCost (ctx, next) {
+    // await _this.validators.ensureUser(ctx, next)
+    await _this.entryRESTController.getBchCost(ctx, next)
   }
 }
 

--- a/src/use-cases/entry/add-entry.js
+++ b/src/use-cases/entry/add-entry.js
@@ -4,28 +4,39 @@
   use case than a replication event triggered by a new entry from a peer database.
 */
 
+// Global npm libraries
+const { Write } = require('p2wdb/index')
+
+// Local libraries
 const DBEntry = require('../../entities/db-entry')
+const config = require('../../../config')
 
 let _this
 
 class AddEntry {
   constructor (localConfig = {}) {
-    if (!localConfig.p2wdbAdapter) {
+    this.adapters = localConfig.adapters
+    if (!this.adapters) {
       throw new Error(
-        'p2wdbAdapter instance must be included when instantiating AddEntry use case'
+        'Instance of adapters must be passed in when instantiating Entry Use Cases library.'
       )
     }
-    this.p2wdbAdapter = localConfig.p2wdbAdapter
-
-    if (!localConfig.entryAdapter) {
+    if (!localConfig.adapters.p2wdb) {
       throw new Error(
-        'entryAdapter instance must be included when instantiating AddEntry use case'
+        'p2wdb adapter instance must be included when instantiating AddEntry use case'
       )
     }
-    this.entryAdapter = localConfig.entryAdapter
+    this.p2wdbAdapter = localConfig.adapters.p2wdb
+    if (!localConfig.adapters.entry) {
+      throw new Error(
+        'entry Adapter instance must be included when instantiating AddEntry use case'
+      )
+    }
+    this.entryAdapter = localConfig.adapters.entry
 
     // Encapsulate dependencies.
     this.dbEntry = new DBEntry()
+    this.config = config
 
     _this = this
   }
@@ -52,7 +63,7 @@ class AddEntry {
 
       return hash
     } catch (err) {
-      console.error('Error in addEntry.add()')
+      console.error('Error in add-entry.js/addUserEntry(): ', err)
       throw err
     }
   }
@@ -96,6 +107,63 @@ class AddEntry {
       console.log('Error in _extractAppId(): ', err)
       // Exit quietly.
       return peerData
+    }
+  }
+
+  // User is paying in BCH for P2WDB instance to burn PSF tokens and write
+  // data on their behalf.
+  async addBchEntry (rawData) {
+    try {
+      // const { address, data, appId } = rawData
+      const { address, data, appId } = rawData
+
+      // Verify that bchPayment model exists.
+      const BchPaymentModel = this.adapters.localdb.BchPayment
+      const bchPayment = await BchPaymentModel.findOne({ address })
+      console.log('bchPayment: ', bchPayment)
+
+      // Throw error if bchPayment does not exist.
+      if (!bchPayment) {
+        throw new Error('Payment model not found. Call POST /entry/cost/bch first to get a BCH payment address.')
+      }
+
+      // Verify that address has the required BCH payment.
+      const requiredFee = bchPayment.bchCost
+      const balance = await this.adapters.wallet.bchWallet.getBalance(address)
+      console.log('balance: ', balance)
+
+      // Throw error if address does not have the necessary payment.
+      if (balance < requiredFee) {
+        throw new Error(`The balance of address ${address} is ${requiredFee} sats, which is less than the required fee of ${balance} sats.`)
+      }
+
+      // Get the private key for the payment address.
+      const keyPair = await this.adapters.wallet.getKeyPair(bchPayment.hdIndex)
+      if (keyPair.cashAddress !== address) {
+        throw new Error(`Unexpected error: HD index ${bchPayment.hdIndex} generated address ${keyPair.cashAddress}, which does not match expected address ${address}`)
+      }
+
+      // Instantiate a wallet using the addresses private key.
+      const tempWallet = new this.adapters.wallet.BchWallet(keyPair.wif, { interface: 'consumer-api' })
+      await tempWallet.walletInfoPromise
+
+      // Move payment to app's root address.
+      const rootAddr = this.adapters.wallet.bchWallet.walletInfo.cashAddress
+      const txid1 = await tempWallet.sendAll(rootAddr)
+      console.log(`Sent ${balance} sats to root address ${rootAddr}. TXID: ${txid1}`)
+
+      // Delete the database model.
+      await bchPayment.remove()
+
+      // Write an entry to this P2WDB, using the PSF tokens in this apps wallet.
+      const appWif = this.adapters.wallet.bchWallet.walletInfo.privateKey
+      const write = new Write({ wif: appWif, serverURL: `http://localhost:${this.config.port}` })
+      const hash = await write.postEntry(data, appId)
+
+      return hash
+    } catch (err) {
+      console.error('Error in add-entry.js/addBchEntry(): ', err)
+      throw err
     }
   }
 }

--- a/src/use-cases/entry/add-entry.js
+++ b/src/use-cases/entry/add-entry.js
@@ -121,7 +121,7 @@ class AddEntry {
       // Verify that bchPayment model exists.
       const BchPaymentModel = this.adapters.localdb.BchPayment
       const bchPayment = await BchPaymentModel.findOne({ address })
-      console.log('bchPayment: ', bchPayment)
+      // console.log('bchPayment: ', bchPayment)
 
       // Throw error if bchPayment does not exist.
       if (!bchPayment) {
@@ -131,7 +131,7 @@ class AddEntry {
       // Verify that address has the required BCH payment.
       const requiredFee = bchPayment.bchCost
       const balance = await this.adapters.wallet.bchWallet.getBalance(address)
-      console.log('balance: ', balance)
+      // console.log('balance: ', balance)
 
       // Throw error if address does not have the necessary payment.
       if (balance < requiredFee) {
@@ -143,11 +143,11 @@ class AddEntry {
       if (keyPair.cashAddress !== address) {
         throw new Error(`Unexpected error: HD index ${bchPayment.hdIndex} generated address ${keyPair.cashAddress}, which does not match expected address ${address}`)
       }
-      console.log('keyPair: ', keyPair)
+      // console.log('keyPair: ', keyPair)
 
       // Instantiate a wallet using the addresses private key.
       // const tempWallet = new this.adapters.wallet.BchWallet(keyPair.wif, { interface: 'consumer-api' })
-      const tempWallet = await this.createTempWallet(keyPair.wif)
+      const tempWallet = await this._createTempWallet(keyPair.wif)
       await tempWallet.initialize()
 
       // Move payment to app's root address.
@@ -165,13 +165,13 @@ class AddEntry {
 
       return hash
     } catch (err) {
-      console.error('Error in add-entry.js/addBchEntry(): ', err)
+      console.error('Error in add-entry.js/addBchEntry()')
       throw err
     }
   }
 
   // This function is used for easier mocking during tests.
-  async createTempWallet (wif) {
+  async _createTempWallet (wif) {
     const tempWallet = new this.adapters.wallet.BchWallet(wif, { interface: 'consumer-api' })
     await tempWallet.walletInfoPromise
     return tempWallet

--- a/src/use-cases/entry/cost.js
+++ b/src/use-cases/entry/cost.js
@@ -10,6 +10,9 @@ class Cost {
         'Instance of adapters must be passed in when instantiating Cost Use Cases library.'
       )
     }
+
+    // Encapsulate dependencies
+    this.BchPaymentModel = this.adapters.localdb.BchPayment
   }
 
   // Retrieve the current write cost in PSF tokens.
@@ -28,12 +31,35 @@ class Cost {
     return psfCost
   }
 
+  // This function is called by the entry/cost/bch REST API endpoint. It
+  // calculates the cost of a write in terms of BCH (plus convenience fee),
+  // it generates a keypair from the HD wallet, and stores all this data
+  // as a Mongo bchPayment model. When a user submits a write, the model is
+  // used to verify payment before burning PSF and writing the data to the
+  // database on behalf of the user.
   async getBchCost () {
-    // Placeholder
-    const address = 'bitcoincash:qqsrke9lh257tqen99dkyy2emh4uty0vky9y0z0lsr'
-
+    // Calculate the cost of a P2WDB write in terms of BCH.
     const bchCost = await this.adapters.writePrice.getWriteCostInBch()
 
+    // Generate a key pair
+    const { cashAddress, hdIndex } = await this.adapters.wallet.getKeyPair()
+    const address = cashAddress
+
+    // Create a time stamp.
+    const now = new Date()
+    const timeCreated = now.toISOString()
+
+    // Create a new database model to save this data.
+    const dbObj = {
+      address,
+      hdIndex,
+      timeCreated,
+      bchCost
+    }
+    const bchPaymentModel = new this.BchPaymentModel(dbObj)
+    await bchPaymentModel.save()
+
+    // Return the payment data to the user.
     return { bchCost, address }
   }
 }

--- a/src/use-cases/entry/cost.js
+++ b/src/use-cases/entry/cost.js
@@ -27,6 +27,15 @@ class Cost {
 
     return psfCost
   }
+
+  async getBchCost () {
+    // Placeholder
+    const address = 'bitcoincash:qqsrke9lh257tqen99dkyy2emh4uty0vky9y0z0lsr'
+
+    const bchCost = await this.adapters.writePrice.getWriteCostInBch()
+
+    return { bchCost, address }
+  }
 }
 
 module.exports = Cost

--- a/src/use-cases/entry/index.js
+++ b/src/use-cases/entry/index.js
@@ -19,10 +19,11 @@ class EntryUseCases {
     }
 
     // Instantiate the use cases.
-    this.addEntry = new AddEntry({
-      p2wdbAdapter: this.adapters.p2wdb,
-      entryAdapter: this.adapters.entry
-    })
+    // this.addEntry = new AddEntry({
+    //   p2wdbAdapter: this.adapters.p2wdb,
+    //   entryAdapter: this.adapters.entry
+    // })
+    this.addEntry = new AddEntry(localConfig)
 
     this.readEntry = new ReadEntry({ p2wdbAdapter: this.adapters.p2wdb })
 

--- a/test/integration/adapters/write-price-integration.js
+++ b/test/integration/adapters/write-price-integration.js
@@ -2,6 +2,8 @@
   Integration tests for write-price.js adapter library
 */
 
+const assert = require('chai').assert
+
 const WritePrice = require('../../../src/adapters/write-price')
 
 describe('#write-price', () => {
@@ -18,10 +20,28 @@ describe('#write-price', () => {
     })
   })
 
-  describe('#getWriteCostPsf', () => {
-    it('should get the write price from the token', async () => {
-      const result = await uut.getWriteCostPsf()
+  // describe('#getCurrentCostPSF', () => {
+  //   it('should get the write price from the token', async () => {
+  //     const result = await uut.getCurrentCostPSF()
+  //     console.log('result: ', result)
+  //   })
+  // })
+
+  describe('#getPsfPriceInBch', () => {
+    it('should get the price of PSF tokens in BCH', async () => {
+      const result = await uut.getPsfPriceInBch()
       console.log('result: ', result)
+
+      assert.isAbove(result, 0)
+    })
+  })
+
+  describe('#getWriteCostInBch', () => {
+    it('should get the price to write to P2WDB in BCH', async () => {
+      const result = await uut.getWriteCostInBch()
+      console.log('result: ', result)
+
+      // assert.isAbove(result, 0)
     })
   })
 })

--- a/test/unit/adapters/wallet.adapter.unit.js
+++ b/test/unit/adapters/wallet.adapter.unit.js
@@ -1,0 +1,196 @@
+/*
+  Unit tests for the Wallet Adapter library.
+*/
+
+// Public npm libraries.
+const assert = require('chai').assert
+const sinon = require('sinon')
+const fs = require('fs')
+// const BCHJS = require('@psf/bch-js')
+
+// Local libraries.
+const WalletAdapter = require('../../../src/adapters/wallet')
+const { MockBchWallet } = require('../mocks/adapters/wallet')
+
+// Global constants
+const testWalletFile = `${__dirname.toString()}/test-wallet.json`
+
+describe('#wallet', () => {
+  let uut
+  let sandbox
+
+  before(() => {
+    // Delete the test file if it exists.
+    try {
+      deleteFile(testWalletFile)
+    } catch (err) {}
+  })
+
+  beforeEach(() => {
+    uut = new WalletAdapter()
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => sandbox.restore())
+
+  after(() => {
+    // Delete the test file if it exists.
+    try {
+      deleteFile(testWalletFile)
+    } catch (err) {}
+  })
+
+  describe('#openWallet', () => {
+    it('should create a new wallet what wallet file does not exist', async () => {
+      // Mock dependencies
+      uut.BchWallet = MockBchWallet
+
+      // Ensure we open the test file, not the production wallet file.
+      uut.WALLET_FILE = testWalletFile
+
+      const result = await uut.openWallet()
+      // console.log('result: ', result)
+
+      assert.property(result, 'mnemonic')
+      assert.property(result, 'privateKey')
+      assert.property(result, 'publicKey')
+      assert.property(result, 'cashAddress')
+      assert.property(result, 'address')
+      assert.property(result, 'slpAddress')
+      assert.property(result, 'legacyAddress')
+      assert.property(result, 'hdPath')
+    })
+
+    it('should open existing wallet file', async () => {
+      // This test case uses the file created in the previous test case.
+
+      // Ensure we open the test file, not the production wallet file.
+      uut.WALLET_FILE = testWalletFile
+
+      const result = await uut.openWallet()
+      // console.log('result: ', result)
+
+      assert.property(result, 'mnemonic')
+      assert.property(result, 'privateKey')
+      assert.property(result, 'publicKey')
+      assert.property(result, 'cashAddress')
+      assert.property(result, 'address')
+      assert.property(result, 'slpAddress')
+      assert.property(result, 'legacyAddress')
+      assert.property(result, 'hdPath')
+    })
+
+    it('should catch and throw an error', async () => {
+      try {
+        // Force an error
+        uut.WALLET_FILE = ''
+        uut.BchWallet = () => {
+        }
+
+        await uut.openWallet()
+        // console.log('result: ', result)
+
+        assert.fail('Unexpected code path')
+      } catch (err) {
+        // console.log('err: ', err)
+        assert.include(err.message, 'this.BchWallet is not a constructor')
+      }
+    })
+  })
+
+  describe('#instanceWallet', () => {
+    // it('should create an instance of BchWallet', async () => {
+    //   // Mock dependencies
+    //   uut.BchWallet = MockBchWallet
+    //
+    //   // Ensure we open the test file, not the production wallet file.
+    //   uut.WALLET_FILE = testWalletFile
+    //
+    //   const walletData = await uut.openWallet()
+    //
+    //   const result = await uut.instanceWallet(walletData.mnemonic)
+    //   console.log('result: ', result)
+    //
+    //   assert.property(result, 'walletInfoPromise')
+    // })
+
+    it('should catch and throw an error', async () => {
+      try {
+        await uut.instanceWallet()
+
+        assert.fail('Unexpected code path')
+      } catch (err) {
+        // console.log('err: ', err)
+        assert.include(err.message, 'Cannot read')
+      }
+    })
+  })
+
+  describe('#incrementNextAddress', () => {
+    it('should increment the nextAddress property', async () => {
+      // Ensure we open the test file, not the production wallet file.
+      uut.WALLET_FILE = testWalletFile
+
+      // mock instance of minimal-slp-wallet
+      uut.bchWallet = new MockBchWallet()
+
+      const result = await uut.incrementNextAddress()
+
+      assert.equal(result, 2)
+    })
+
+    it('should catch and throw an error', async () => {
+      try {
+        // Force an error
+        sandbox.stub(uut, 'openWallet').rejects(new Error('test error'))
+
+        await uut.incrementNextAddress()
+
+        assert.fail('Unexpected code path')
+      } catch (err) {
+        assert.include(err.message, 'test error')
+      }
+    })
+  })
+
+  describe('#getKeyPair', () => {
+    it('should return an object with a key pair', async () => {
+      // Ensure we open the test file, not the production wallet file.
+      uut.WALLET_FILE = testWalletFile
+
+      // mock instance of minimal-slp-wallet
+      uut.bchWallet = new MockBchWallet()
+
+      const result = await uut.getKeyPair()
+      // console.log('result: ', result)
+
+      assert.property(result, 'cashAddress')
+      assert.property(result, 'wif')
+      assert.property(result, 'hdIndex')
+    })
+
+    it('should catch and throw an error', async () => {
+      try {
+        // Force an error
+        sandbox
+          .stub(uut, 'incrementNextAddress')
+          .rejects(new Error('test error'))
+
+        await uut.getKeyPair()
+
+        assert.fail('Unexpected code path')
+      } catch (err) {
+        assert.include(err.message, 'test error')
+      }
+    })
+  })
+})
+
+const deleteFile = (filepath) => {
+  try {
+    // Delete state if exist
+    fs.unlinkSync(filepath)
+  } catch (err) {
+    // console.error('Error trying to delete file: ', err)
+  }
+}

--- a/test/unit/mocks/adapters/index.js
+++ b/test/unit/mocks/adapters/index.js
@@ -88,6 +88,12 @@ const localdb = {
     }
   },
 
+  BchPayment: class BchPayment {
+    async save () {
+      return {}
+    }
+  },
+
   validatePassword: () => {
     return true
   }
@@ -95,7 +101,12 @@ const localdb = {
 
 const writePrice = {
   currentRate: 0.133,
-  getTargetCostPsf: () => 0.133
+  getTargetCostPsf: () => 0.133,
+  getWriteCostInBch: async () => {}
 }
 
-module.exports = { ipfs, localdb, p2wdb, entry, webhook, writePrice }
+const wallet = {
+  getKeyPair: async () => {}
+}
+
+module.exports = { ipfs, localdb, p2wdb, entry, webhook, writePrice, wallet }

--- a/test/unit/mocks/adapters/index.js
+++ b/test/unit/mocks/adapters/index.js
@@ -2,6 +2,8 @@
   Mocks for the Adapter library.
 */
 
+const BchWallet = require('minimal-slp-wallet/index')
+
 class IpfsAdapter {
   constructor () {
     this.ipfs = {
@@ -115,7 +117,9 @@ const wallet = {
       cashAddress: 'bitcoincash:qza7sy8jnljkhtt7tgnq5z7f8g7wjgumcyj8rc8duu'
     },
     getBalance: async () => {}
-  }
+  },
+
+  BchWallet: BchWallet
 }
 
 module.exports = { ipfs, localdb, p2wdb, entry, webhook, writePrice, wallet }

--- a/test/unit/mocks/adapters/index.js
+++ b/test/unit/mocks/adapters/index.js
@@ -89,6 +89,8 @@ const localdb = {
   },
 
   BchPayment: class BchPayment {
+    static findOne () {}
+
     async save () {
       return {}
     }
@@ -106,7 +108,14 @@ const writePrice = {
 }
 
 const wallet = {
-  getKeyPair: async () => {}
+  getKeyPair: async () => {},
+
+  bchWallet: {
+    walletInfo: {
+      cashAddress: 'bitcoincash:qza7sy8jnljkhtt7tgnq5z7f8g7wjgumcyj8rc8duu'
+    },
+    getBalance: async () => {}
+  }
 }
 
 module.exports = { ipfs, localdb, p2wdb, entry, webhook, writePrice, wallet }

--- a/test/unit/mocks/adapters/wallet.js
+++ b/test/unit/mocks/adapters/wallet.js
@@ -1,0 +1,143 @@
+/*
+  Mock data for the wallet.adapter.unit.js test file.
+*/
+
+const BCHJS = require('@psf/bch-js')
+
+const mockWallet = {
+  mnemonic: 'course abstract aerobic deer try switch turtle diet fence affair butter top',
+  privateKey: 'L5D2UAam8tvo3uii5kpgaGyjvVMimdrXu8nWGQSQjuuAix6ji1YQ',
+  publicKey: '0379433ffc401483ade310469953c1cba77c71af904f07c15bde330d7198b4d6dc',
+  cashAddress: 'bitcoincash:qzl0d3gcqeypv4cy7gh8rgdszxa9vvm2acv7fqtd00',
+  address: 'bitcoincash:qzl0d3gcqeypv4cy7gh8rgdszxa9vvm2acv7fqtd00',
+  slpAddress: 'simpleledger:qzl0d3gcqeypv4cy7gh8rgdszxa9vvm2acq9zm7d33',
+  legacyAddress: '1JQj1KcQL7GPKzc1D2PvdUSgw3MbDtrHzi',
+  hdPath: "m/44'/245'/0'/0/0",
+  nextAddress: 1
+}
+
+class MockBchWallet {
+  constructor () {
+    this.walletInfoPromise = true
+    this.walletInfo = mockWallet
+    this.bchjs = new BCHJS()
+    this.burnTokens = async () => {
+      return { success: true, txid: 'txid' }
+    }
+    this.sendTokens = async () => {
+      return 'fakeTxid'
+    }
+    this.getUtxos = async () => {
+    }
+    this.getTxData = async () => {
+      return [{
+        tokenTicker: 'TROUT'
+      }]
+    }
+
+    // Environment variable is used by wallet-balance.unit.js to force an error.
+    if (process.env.NO_UTXO) {
+      this.utxos = {}
+    } else {
+      this.utxos = {
+        utxoStore: {
+          address: 'bitcoincash:qqetvdnlt0p8g27dr44cx7h057kpzly9xse9huc97z',
+          bchUtxos: [
+            {
+              height: 700685,
+              tx_hash: '1fc577caaff5626a8477162581e57bae1b19dc6aa6c10638013c2b1ba14dc654',
+              tx_pos: 0,
+              value: 1000,
+              txid: '1fc577caaff5626a8477162581e57bae1b19dc6aa6c10638013c2b1ba14dc654',
+              vout: 0,
+              isValid: false
+            },
+            {
+              height: 700685,
+              tx_hash: '1fc577caaff5626a8477162581e57bae1b19dc6aa6c10638013c2b1ba14dc654',
+              tx_pos: 2,
+              value: 19406,
+              txid: '1fc577caaff5626a8477162581e57bae1b19dc6aa6c10638013c2b1ba14dc654',
+              vout: 2,
+              isValid: false
+            }
+          ],
+          nullUtxos: [],
+          slpUtxos: {
+            type1: {
+              mintBatons: [],
+              tokens: [
+                {
+                  'height': 717331,
+                  'tx_hash': '74889580bb1a5f8c026aa2f55118ac9917df3332f7abae72a70343daa1c29621',
+                  'tx_pos': 1,
+                  'value': 546,
+                  'txid': '74889580bb1a5f8c026aa2f55118ac9917df3332f7abae72a70343daa1c29621',
+                  'vout': 1,
+                  'isSlp': true,
+                  'type': 'token',
+                  'qty': '10',
+                  'tokenId': '600ee24d0f208aebc2bdd2c4ee1b9acb6d57343561442e8676b5bbea311d5a0f',
+                  'address': 'bitcoincash:qqraj35x6l2qyqhjm5l7qlt7z2245ez8l5z3dwkeq5',
+                  'ticker': 'FLIPS',
+                  'name': 'FLIPS',
+                  'documentUri': '',
+                  'documentHash': '',
+                  'decimals': 1,
+                  'qtyStr': '1'
+                },
+                {
+                  'height': 730597,
+                  'tx_hash': '52520faddfafc46b8f8c9548b097f3a3b82a5bf363b5095047b9c5f83247fe36',
+                  'tx_pos': 1,
+                  'value': 546,
+                  'txid': '52520faddfafc46b8f8c9548b097f3a3b82a5bf363b5095047b9c5f83247fe36',
+                  'vout': 1,
+                  'isSlp': true,
+                  'type': 'token',
+                  'qty': '34999991',
+                  'tokenId': '38e97c5d7d3585a2cbf3f9580c82ca33985f9cb0845d4dcce220cb709f9538b0',
+                  'address': 'bitcoincash:qqraj35x6l2qyqhjm5l7qlt7z2245ez8l5z3dwkeq5',
+                  'ticker': 'PSF',
+                  'name': 'Permissionless Software Foundation',
+                  'documentUri': 'psfoundation.cash',
+                  'documentHash': '',
+                  'decimals': 8,
+                  'qtyStr': '0.34999991'
+                },
+                {
+                  'height': 730597,
+                  'tx_hash': '5dc7e7c91382aed1666a51212dfb74050261e12c3c4f62b6b1e57f42d6c51ee1',
+                  'tx_pos': 2,
+                  'value': 546,
+                  'txid': '5dc7e7c91382aed1666a51212dfb74050261e12c3c4f62b6b1e57f42d6c51ee1',
+                  'vout': 2,
+                  'isSlp': true,
+                  'type': 'token',
+                  'qty': '18898',
+                  'tokenId': 'a4fb5c2da1aa064e25018a43f9165040071d9e984ba190c222a7f59053af84b2',
+                  'address': 'bitcoincash:qqraj35x6l2qyqhjm5l7qlt7z2245ez8l5z3dwkeq5',
+                  'ticker': 'TROUT',
+                  'name': "Trout's test token",
+                  'documentUri': 'troutsblog.com',
+                  'documentHash': '',
+                  'decimals': 2,
+                  'qtyStr': '188.98'
+                }
+              ]
+            },
+            nft: {
+              tokens: []
+            },
+            group: {
+              tokens: [],
+              mintBatons: []
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+module.exports = { MockBchWallet, mockWallet}

--- a/test/unit/mocks/use-cases/index.js
+++ b/test/unit/mocks/use-cases/index.js
@@ -67,7 +67,9 @@ class UseCasesMock {
       }
     },
     cost: {
-      getPsfCost: () => {}
+      getPsfCost: async () => {},
+      getPsfCostTarget: async () => {},
+      getBchCost: async () => {}
     }
   }
 }

--- a/test/unit/use-cases/entry/add.entry.use-case.unit.js
+++ b/test/unit/use-cases/entry/add.entry.use-case.unit.js
@@ -2,9 +2,13 @@
   Unit tests for the P2WDB Add Entry Use Cases
 */
 
+// Global npm libraries
 const assert = require('chai').assert
 const sinon = require('sinon')
+const BchWallet = require('minimal-slp-wallet/index')
+const clone = require('lodash.clonedeep')
 
+// Local libraries
 const AddEntry = require('../../../../src/use-cases/entry/add-entry')
 
 // Mocks
@@ -18,10 +22,15 @@ describe('#AddEntry', () => {
   before(async () => {})
 
   beforeEach(() => {
-    uut = new AddEntry({
-      p2wdbAdapter: adaptersMock.p2wdb,
-      entryAdapter: adaptersMock.entry
-    })
+    // uut = new AddEntry({
+    //   p2wdbAdapter: adaptersMock.p2wdb,
+    //   entryAdapter: adaptersMock.entry
+    // })
+
+    // console.log('adaptersMock: ', adaptersMock)
+    const adapters = clone(adaptersMock)
+    // console.log('adapters: ', adapters)
+    uut = new AddEntry({ adapters })
 
     rawData = {
       hash: 'zdpuAuxCW346zUG71Aai21Y31EJ1XNxcjXV5rz93DxftKnpjn',
@@ -39,7 +48,7 @@ describe('#AddEntry', () => {
   afterEach(() => sandbox.restore())
 
   describe('#constructor', () => {
-    it('should throw an error if p2wdb instance is not included', () => {
+    it('should throw an error if adapters instance is not included', () => {
       try {
         uut = new AddEntry()
 
@@ -47,20 +56,39 @@ describe('#AddEntry', () => {
       } catch (err) {
         assert.include(
           err.message,
-          'p2wdbAdapter instance must be included when instantiating AddEntry'
+          'Instance of adapters must be passed in when instantiating Entry Use Cases library.'
+        )
+      }
+    })
+
+    it('should throw an error if p2wdb instance is not included', () => {
+      try {
+        const adapters = clone(adaptersMock)
+        delete adapters.p2wdb
+
+        uut = new AddEntry({ adapters })
+
+        assert.fail('Unexpected code path')
+      } catch (err) {
+        assert.include(
+          err.message,
+          'p2wdb adapter instance must be included when instantiating AddEntry'
         )
       }
     })
 
     it('should throw an error if entry adapter instance is not included', () => {
       try {
-        uut = new AddEntry({ p2wdbAdapter: {} })
+        const adapters = clone(adaptersMock)
+        delete adapters.entry
+
+        uut = new AddEntry({ adapters })
 
         assert.fail('Unexpected code path')
       } catch (err) {
         assert.include(
           err.message,
-          'entryAdapter instance must be included when instantiating AddEntry use case'
+          'entry adapter instance must be included when instantiating AddEntry use case'
         )
       }
     })
@@ -145,6 +173,48 @@ describe('#AddEntry', () => {
       // console.log('result: ', result)
 
       assert.include(result, 'test')
+    })
+  })
+
+  describe('#addBchEntry', () => {
+    it('should write an entry to the P2WDB', async () => {
+      // Mock dependencies
+      sandbox.stub(uut.adapters.localdb.BchPayment, 'findOne').resolves({
+        _id: '63054bb29ebc5f612533845a',
+        address: 'bitcoincash:qqy9qhr67mq6fcudvq8vgnzrn798gf3wjyfyhapz59',
+        hdIndex: '5',
+        timeCreated: '2022-08-23T21:50:42.253Z',
+        bchCost: '0.00011073',
+        __v: 0,
+        remove: async () => {}
+      })
+      sandbox.stub(uut.adapters.wallet.bchWallet, 'getBalance').resolves(11073)
+      sandbox.stub(uut.adapters.wallet, 'getKeyPair').resolves({
+        cashAddress: 'bitcoincash:qza7sy8jnljkhtt7tgnq5z7f8g7wjgumcyj8rc8duu',
+        wif: 'L2WXayLcTiX6GoZ9Mk5tPNRDVcmYhFP5KMUU1p8sdJwXpVytXnTS',
+        hdIndex: '6'
+      })
+
+      // Mock BCH wallet
+      const tempWallet = new BchWallet()
+      await tempWallet.walletInfoPromise
+      sandbox.stub(tempWallet, 'initialize').resolves()
+      sandbox.stub(tempWallet, 'sendAll').resolves('fake-txid')
+      sandbox.stub(uut, 'createTempWallet').resolves(tempWallet)
+
+      // Mock the P2WDB library
+      uut.Write = class Write {
+        async postEntry () { return 'fake-hash' }
+      }
+
+      const data = {
+        address: 'bitcoincash:qza7sy8jnljkhtt7tgnq5z7f8g7wjgumcyj8rc8duu',
+        data: 'fake-data',
+        appId: 'fake-appId'
+      }
+
+      const result = await uut.addBchEntry(data)
+      console.log('result: ', result)
     })
   })
 })

--- a/test/unit/use-cases/entry/cost.entry.use-case.unit.js
+++ b/test/unit/use-cases/entry/cost.entry.use-case.unit.js
@@ -60,85 +60,20 @@ describe('#Cost', () => {
     })
   })
 
-  // describe('#addUserEntry', () => {
-  //   it('should throw an error if entry already exists in the database.', async () => {
-  //     try {
-  //       // Mock dependencies.
-  //       sandbox.stub(uut.entryAdapter, 'doesEntryExist').resolves(true)
-  //
-  //       await uut.addUserEntry(rawData)
-  //
-  //       assert.fail('Unexpected code path')
-  //     } catch (err) {
-  //       assert.include(err.message, 'Entry already exists in the database.')
-  //     }
-  //   })
-  //
-  //   it('should add an entry to the P2WDB', async () => {
-  //     // Mock dependencies
-  //     // console.log('uut.entryAdapter: ', uut.entryAdapter)
-  //     sandbox.stub(uut.entryAdapter, 'doesEntryExist').resolves(false)
-  //     sandbox.stub(uut.p2wdbAdapter, 'insert').resolves('test-hash')
-  //
-  //     const result = await uut.addUserEntry(rawData)
-  //
-  //     assert.equal(result, 'test-hash')
-  //   })
-  // })
+  describe('#getBchCost', () => {
+    it('should generate a new DB model and return an address and cost', async () => {
+      // Mock dependencies
+      sandbox.stub(uut.adapters.writePrice, 'getWriteCostInBch').resolves(0.0001)
+      sandbox.stub(uut.adapters.wallet, 'getKeyPair').resolves({
+        cashAddress: 'testAddr',
+        hdIndex: 2
+      })
 
-  // describe('#addPeerEntry', () => {
-  //   it('should throw an error if entry already exists in the database.', async () => {
-  //     try {
-  //       // Mock dependencies.
-  //       sandbox.stub(uut.entryAdapter, 'doesEntryExist').resolves(true)
-  //
-  //       await uut.addPeerEntry(rawData)
-  //
-  //       assert.fail('Unexpected code path')
-  //     } catch (err) {
-  //       assert.include(err.message, 'Entry already exists in the database.')
-  //     }
-  //   })
-  //
-  //   it('should add an entry to the P2WDB', async () => {
-  //     // Mock dependencies
-  //     sandbox.stub(uut.entryAdapter, 'doesEntryExist').resolves(false)
-  //
-  //     const result = await uut.addPeerEntry(rawData)
-  //
-  //     assert.equal(result, true)
-  //   })
-  // })
+      const result = await uut.getBchCost()
+      // console.log('result: ', result)
 
-  // describe('#_extractAppId', () => {
-  //   it('should extract appId from data', () => {
-  //     // Create test data for input.
-  //     const peerData = {
-  //       data: {
-  //         appId: 'test'
-  //       }
-  //     }
-  //     peerData.data = JSON.stringify(peerData.data)
-  //
-  //     const result = uut._extractAppId(peerData)
-  //     // console.log('result: ', result)
-  //
-  //     assert.equal(result.appId, 'test')
-  //   })
-  //
-  //   it('should exit quietly when there is an error, and returns input data.', () => {
-  //     // Create test data for input.
-  //     let peerData = {
-  //       data: {
-  //         appId: 'test'
-  //       }
-  //     }
-  //     peerData = JSON.stringify(peerData)
-  //
-  //     const result = uut._extractAppId(peerData)
-  //     // console.log('result: ', result)
-  //
-  //     assert.include(result, 'test')
-  //   })
-  // })
+      assert.equal(result.bchCost, 0.0001)
+      assert.equal(result.address, 'testAddr')
+    })
+  })
 })

--- a/util/bch-payment/delete-all-bch-payments.js
+++ b/util/bch-payment/delete-all-bch-payments.js
@@ -1,0 +1,33 @@
+const mongoose = require('mongoose')
+
+// Force test environment
+// make sure environment variable is set before this file gets called.
+// see test script in package.json.
+// process.env.KOA_ENV = 'test'
+const config = require('../../config')
+
+const BchPayment = require('../../src/adapters/localdb/models/bch-payment')
+
+async function deleteBchPayment () {
+  // Connect to the Mongo Database.
+  mongoose.Promise = global.Promise
+  mongoose.set('useCreateIndex', true) // Stop deprecation warning.
+  await mongoose.connect(config.database, {
+    useUnifiedTopology: true,
+    useNewUrlParser: true
+  })
+
+  // Get all the users in the DB.
+  const bchPayments = await BchPayment.find({})
+  // console.log(`users: ${JSON.stringify(users, null, 2)}`)
+
+  // Delete each user.
+  for (let i = 0; i < bchPayments.length; i++) {
+    const thisPayment = bchPayments[i]
+    await thisPayment.remove()
+  }
+
+  mongoose.connection.close()
+}
+
+deleteBchPayment()

--- a/util/bch-payment/getBchPayments.js
+++ b/util/bch-payment/getBchPayments.js
@@ -1,0 +1,21 @@
+const mongoose = require('mongoose')
+
+const config = require('../../config')
+
+const BchPayment = require('../../src/adapters/localdb/models/bch-payment')
+
+async function getBchPayments () {
+  // Connect to the Mongo Database.
+  mongoose.Promise = global.Promise
+  mongoose.set('useCreateIndex', true) // Stop deprecation warning.
+  await mongoose.connect(
+    config.database,
+    { useNewUrlParser: true, useUnifiedTopology: true }
+  )
+
+  const bchPayments = await BchPayment.find({})
+  console.log(`payment entries: ${JSON.stringify(bchPayments, null, 2)}`)
+
+  mongoose.connection.close()
+}
+getBchPayments()


### PR DESCRIPTION
This is a major feature upgrade. It adds an optional feature for paying to write to the database in BCH, instead of PSF tokens.

This optional service can be turned on by doing the following:
- Set the `ENABLE_BCH_PAYMENT` environment variable to 1 (or some true value) before running the P2WDB service.
- Create a `wallet.json` file in the root directory by running the `production/scripts/create-wallet.js` script
- Deposit PSF tokens into the newly created wallet

If the above steps are completed, then users can pay for a write to the P2WDB using only BCH. The service will burn the required amount of PSF tokens on behalf of the user. It will add a convenience fee, which is set to 10% by default. In the future, different instances of the P2WDB can compete on the rate they charge.

From a users standpoint, they have to call two API endpoints:

- POST /entry/cost/bch to get a price (in BCH) and an address to pay
- POST /entry/write/bch to write data after paying the BCH to the address in the first call.

Those two endpoints will be added to the [p2wdb](https://www.npmjs.com/package/p2wdb) npm library.