### PR TITLE
GET /entry/balance for testing liveness and wallet balances

### DIFF
--- a/shell-scripts/local-external-ipfs-node.sh
+++ b/shell-scripts/local-external-ipfs-node.sh
@@ -30,6 +30,6 @@ export P2W_ENV=production
 export DBURL=mongodb://localhost:27017/p2wdb-service-dev
 
 # Enable BCH payments for P2WDB writes
-#export ENABLE_BCH_PAYMENT=1
+export ENABLE_BCH_PAYMENT=1
 
 npm start

--- a/src/adapters/wallet.js
+++ b/src/adapters/wallet.js
@@ -242,6 +242,14 @@ class WalletAdapter {
 
     return true
   }
+
+  async getBalance () {
+    const balance = await this.bchWallet.getBalance()
+    console.log('balance: ', balance)
+
+    const tokens = await this.bchWallet.listTokens()
+    console.log('tokens: ', tokens)
+  }
 }
 
 module.exports = WalletAdapter

--- a/src/adapters/wallet.js
+++ b/src/adapters/wallet.js
@@ -243,12 +243,31 @@ class WalletAdapter {
     return true
   }
 
+  // Get the balance of the wallet in sats and PSF tokens.
+  // This function is called by the GET /entry/balance controller.
   async getBalance () {
     const balance = await this.bchWallet.getBalance()
-    console.log('balance: ', balance)
+    // console.log('balance: ', balance)
 
     const tokens = await this.bchWallet.listTokens()
-    console.log('tokens: ', tokens)
+    // console.log('tokens: ', tokens)
+
+    // Find the array entry for the PSF token
+    const psfTokens = tokens.find(x => x.tokenId === '38e97c5d7d3585a2cbf3f9580c82ca33985f9cb0845d4dcce220cb709f9538b0')
+    // console.log('psfTokens: ', psfTokens)
+
+    let psfBalance = 0
+    if (psfTokens) {
+      psfBalance = psfTokens.qty
+    }
+
+    const outObj = {
+      satBalance: balance,
+      psfBalance,
+      success: true
+    }
+
+    return outObj
   }
 }
 

--- a/src/controllers/rest-api/entry/controller.js
+++ b/src/controllers/rest-api/entry/controller.js
@@ -627,6 +627,58 @@ class EntryRESTControllerLib {
     }
   }
 
+  /**
+   * @api {get} /entry/balance Get the balance of the apps wallet
+   * @apiPermission public
+   * @apiName P2WDB Wallet Balance
+   * @apiGroup REST P2WDB
+   *
+   * @apiDescription
+   * If this P2WDB is configured as an IPFS pinning cluster, with a crypto wallet,
+   * this endpoint will return the BCH and PSF token balance of that wallet.
+   * This endpoint is handy for checking the health of the node and ensuring
+   * that it is capable of creating new entries for users.
+   *
+   *
+   * @apiExample Example usage:
+   * curl -H "Content-Type: application/json" -X GET localhost:5010/entry/balance
+   *
+   * @apiSuccessExample {json} Success-Response:
+   *  HTTP/1.1 200 OK
+   *  {
+   *     "success": true,
+   *     "bchCost": 0.000106,
+   *     "address": "bitcoincash:qqsrke9lh257tqen99dkyy2emh4uty0vky9y0z0lsr"
+   *  }
+   * @apiError UnprocessableEntity Missing required parameters
+   *
+   * @apiErrorExample {json} Error-Response:
+   *     HTTP/1.1 422 Unprocessable Entity
+   *     {
+   *       "status": 422,
+   *       "error": "Unprocessable Entity"
+   *     }
+   */
+  async getBalance (ctx) {
+    if (!this.config.enableBchPayment) {
+      console.log('Throwing error. This is expected behavior.')
+      ctx.throw(501, 'BCH payments are not enabled in this instance of P2WDB.')
+    }
+
+    try {
+      // Get the cost in PSF tokens to write to the DB.
+      await this.adapters.wallet.getBalance()
+
+      ctx.body = {
+        success: true
+      }
+    } catch (err) {
+      console.log('Error in entry REST API getBchCost() handler.')
+      // throw err
+      _this.handleError(ctx, err)
+    }
+  }
+
   // DRY error handler
   handleError (ctx, err) {
     // If an HTTP status is specified by the buisiness logic, use that.

--- a/src/controllers/rest-api/entry/controller.js
+++ b/src/controllers/rest-api/entry/controller.js
@@ -647,8 +647,8 @@ class EntryRESTControllerLib {
    *  HTTP/1.1 200 OK
    *  {
    *     "success": true,
-   *     "bchCost": 0.000106,
-   *     "address": "bitcoincash:qqsrke9lh257tqen99dkyy2emh4uty0vky9y0z0lsr"
+   *     "satBalance": 41012,
+   *     "psfBalance": 2
    *  }
    * @apiError UnprocessableEntity Missing required parameters
    *
@@ -667,13 +667,11 @@ class EntryRESTControllerLib {
 
     try {
       // Get the cost in PSF tokens to write to the DB.
-      await this.adapters.wallet.getBalance()
+      const balance = await this.adapters.wallet.getBalance()
 
-      ctx.body = {
-        success: true
-      }
+      ctx.body = balance
     } catch (err) {
-      console.log('Error in entry REST API getBchCost() handler.')
+      console.log('Error in entry REST API getBalance() handler.')
       // throw err
       _this.handleError(ctx, err)
     }

--- a/src/controllers/rest-api/entry/index.js
+++ b/src/controllers/rest-api/entry/index.js
@@ -61,6 +61,7 @@ class EntryController {
     this.router.post('/cost/psf', this.getPsfCostTarget)
     this.router.get('/cost/bch', this.getBchCost)
     this.router.post('/write/bch', this.postBchEntry)
+    this.router.get('/balance', this.getBalance)
 
     // Attach the Controller routes to the Koa app.
     app.use(cors({ origin: '*' }))
@@ -111,6 +112,11 @@ class EntryController {
   async getBchCost (ctx, next) {
     // await _this.validators.ensureUser(ctx, next)
     await _this.entryRESTController.getBchCost(ctx, next)
+  }
+
+  async getBalance (ctx, next) {
+    // await _this.validators.ensureUser(ctx, next)
+    await _this.entryRESTController.getBalance(ctx, next)
   }
 }
 

--- a/test/e2e/automated/a10-entry.rest.e2e.js
+++ b/test/e2e/automated/a10-entry.rest.e2e.js
@@ -395,4 +395,28 @@ describe('Entry', () => {
       }
     })
   })
+
+  describe('GET /balance - Get balance of wallet', () => {
+    it('should reject when bch writes are not enabled', async () => {
+      try {
+        const options = {
+          method: 'GET',
+          url: `${LOCALHOST}/entry/balance`,
+          data: {}
+        }
+
+        await axios(options)
+
+        assert(false, 'Unexpected result')
+      } catch (err) {
+        // console.log(err)
+        const status = err.response.status
+        const statusIs422 = status === 422
+        const statusIs501 = status === 501
+        const statusIs422Or501 = statusIs422 || statusIs501
+
+        assert.equal(statusIs422Or501, true)
+      }
+    })
+  })
 })

--- a/test/unit/adapters/wallet.adapter.unit.js
+++ b/test/unit/adapters/wallet.adapter.unit.js
@@ -348,6 +348,33 @@ describe('#wallet', () => {
       assert.equal(result, true)
     })
   })
+
+  describe('#getBalance', () => {
+    it('should get the balance for the wallet', async () => {
+      // mock instance of minimal-slp-wallet
+      uut.bchWallet = new MockBchWallet()
+
+      // Mock dependencies and force desired code path
+      sandbox.stub(uut.bchWallet, 'getBalance').resolves(41012)
+      sandbox.stub(uut.bchWallet, 'listTokens').resolves([{
+        tokenId: '38e97c5d7d3585a2cbf3f9580c82ca33985f9cb0845d4dcce220cb709f9538b0',
+        ticker: 'PSF',
+        name: 'Permissionless Software Foundation',
+        decimals: 8,
+        tokenType: 1,
+        url: 'psfoundation.cash',
+        qty: 2
+      }])
+
+      const result = await uut.getBalance()
+      // console.log('result: ', result)
+
+      // Assert the expected properties exist and have the expected values.
+      assert.equal(result.satBalance, 41012)
+      assert.equal(result.psfBalance, 2)
+      assert.equal(result.success, true)
+    })
+  })
 })
 
 const deleteFile = (filepath) => {

--- a/test/unit/controllers/rest-api/entry/entry.rest.controller.unit.js
+++ b/test/unit/controllers/rest-api/entry/entry.rest.controller.unit.js
@@ -335,6 +335,61 @@ describe('#Entry-REST-Controller', () => {
 
       assert.equal(ctx.body.hash, 'fake-hash')
     })
+
+    it('should catch and throw errors when retrieving BCH cost', async () => {
+      uut.config.enableBchPayment = true
+
+      try {
+        // sandbox.stub(uut.useCases.entry.addEntry, 'addBchEntry').rejects(new Error('test error'))
+
+        await uut.postBchEntry(ctx)
+
+        assert.fail('Unexpected result')
+      } catch (err) {
+        console.log('err: ', err)
+        assert.include(err.message, 'Cannot read')
+      }
+    })
+  })
+
+  describe('#getBalance', () => {
+    it('should throw an error if BCH payments are disabled', async () => {
+      uut.config.enableBchPayment = false
+
+      try {
+        await uut.getBalance(ctx)
+
+        assert.fail('Unexpected code path')
+      } catch (err) {
+        assert.include(err.message, 'BCH payments are not enabled in this instance of P2WDB.')
+      }
+    })
+
+    it('should get the balances of the wallet', async () => {
+      uut.config.enableBchPayment = true
+
+      // Mock dependencies and force desired code path
+      sandbox.stub(uut.adapters.wallet, 'getBalance').resolves({ success: true })
+
+      ctx.request.body = {}
+
+      await uut.getBalance(ctx)
+      assert.equal(ctx.body.success, true)
+    })
+
+    it('should catch and throw errors when retrieving BCH cost', async () => {
+      uut.config.enableBchPayment = true
+
+      try {
+        sandbox.stub(uut.adapters.wallet, 'getBalance').rejects(new Error('test error'))
+
+        await uut.getBalance(ctx)
+
+        assert.fail('Unexpected result')
+      } catch (err) {
+        assert.include(err.message, 'test error')
+      }
+    })
   })
 
   describe('#handleError', () => {

--- a/test/unit/mocks/adapters/index.js
+++ b/test/unit/mocks/adapters/index.js
@@ -120,8 +120,9 @@ const wallet = {
   },
 
   BchWallet: BchWallet,
+  optimize: async () => {},
+  getBalance: async () => {}
 
-  optimize: async () => {}
 }
 
 module.exports = { ipfs, localdb, p2wdb, entry, webhook, writePrice, wallet }

--- a/test/unit/mocks/adapters/wallet.js
+++ b/test/unit/mocks/adapters/wallet.js
@@ -27,8 +27,9 @@ class MockBchWallet {
     this.sendTokens = async () => {
       return 'fakeTxid'
     }
-    this.getUtxos = async () => {
-    }
+    this.getUtxos = async () => {}
+    this.getBalance = async () => {}
+    this.listTokens = async () => {}
     this.getTxData = async () => {
       return [{
         tokenTicker: 'TROUT'


### PR DESCRIPTION
This new REST API endpoint of `GET /entry/balance` is used to test the system for liveness. It returns the BCH and PSF balances of the app wallet if the instance of the P2WDB is configured for BCH payments. 

This allows for an automated test system to alert the admin if the wallet for the instance of the P2WDB needs to be serviced.